### PR TITLE
feat(copilot): scaffold OpenClaw model-routing kit

### DIFF
--- a/copilot/openclaw-model-routing-research-kit/.github/plugin/plugin.json
+++ b/copilot/openclaw-model-routing-research-kit/.github/plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "openclaw-model-routing-research-kit",
+  "description": "Miadi/OpenClaw Copilot kit for model-routing study orchestration, RISE rispec scaffolding, source ledgers, plugin-gap contracts, and final integration handoffs.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Iris/Hermes"
+  },
+  "repository": "https://github.com/jgwill/miadi-orchestration-kit",
+  "license": "MIT",
+  "keywords": [
+    "openclaw",
+    "model-routing",
+    "deep-research",
+    "rise",
+    "miadi"
+  ],
+  "agents": [
+    "./agents"
+  ],
+  "skills": [
+    "./skills/openclaw-model-routing-bootstrap",
+    "./skills/openclaw-source-ledger",
+    "./skills/openclaw-rise-rispec-scaffold",
+    "./skills/openclaw-plugin-gap-contracts",
+    "./skills/model-routing-policy-simulator"
+  ]
+}

--- a/copilot/openclaw-model-routing-research-kit/README.md
+++ b/copilot/openclaw-model-routing-research-kit/README.md
@@ -1,0 +1,64 @@
+# OpenClaw Model-Routing Research Kit
+
+Purpose-built Copilot plugin dir for the Miadi/OpenClaw model-routing study. It gives Iris/Hermes a reusable launch surface for study preflight, source ledgers, RISE rispec scaffolding, plugin-gap contracts, model-routing matrix work, and final integration handoffs.
+
+## Included Agents
+
+| Agent | Use |
+| --- | --- |
+| `openclaw-study-orchestrator` | Runs preflight, validates the launch manifest, enforces track order, scopes, token caps, and stop conditions. |
+| `openclaw-source-ledger-reviewer` | Reviews claim ledgers, evidence quality, contradictions, and claim-to-source coverage before synthesis. |
+| `openclaw-rispec-scaffold-reviewer` | Checks OpenClaw rispec folders against the RISE phase wording and the standard 5-file shape. |
+| `openclaw-final-integrator` | Integrates track handoffs, source ledgers, routing matrix updates, plugin gaps, and acceptance status. |
+
+## Included Skills
+
+| Skill | Use |
+| --- | --- |
+| `openclaw-model-routing-bootstrap` | Fixed-order study bootstrap, launch manifest validation, write-scope discipline, token caps, issue links, and stop rules. |
+| `openclaw-source-ledger` | Source ledger rules for evidence types, quality ratings, contradiction handling, and claim-to-source mapping. |
+| `openclaw-rise-rispec-scaffold` | RISE scaffold process using `Reverse-engineer -> Intent-extract -> Specify -> Export`. |
+| `openclaw-plugin-gap-contracts` | Reconciles missing plugin names and prevents live connector gaps from blocking read-only research. |
+| `model-routing-policy-simulator` | Produces or revises the model-routing matrix from task, risk, context, cost, latency, and review constraints. |
+
+## Included Templates
+
+| Template | Use |
+| --- | --- |
+| `templates/launch-manifest.md` | Control file for track order, write paths, plugin dirs, add-dir paths, issue links, token caps, and stop conditions. |
+| `templates/track-handoff.md` | Required closeout format for each delegated wave or Copilot track. |
+| `templates/source-ledger.md` | Claim ledger with source type, evidence quality, contradictions, and verification status. |
+| `templates/model-routing-matrix.md` | Seed model-routing matrix with required input and output columns. |
+| `templates/acceptance-checklist.md` | Preflight and final acceptance checks for the study kit and track outputs. |
+
+## Cheap Smoke Test
+
+```bash
+copilot --model gpt-5-mini --reasoning-effort high --yolo --no-ask-user \
+  --plugin-dir /workspace/repos/jgwill/miadi-orchestration-kit/copilot/openclaw-model-routing-research-kit \
+  --add-dir /workspace/repos/miadisabelle/workspace-openclaw \
+  --add-dir /workspace/repos/jgwill/miadi-orchestration-kit \
+  -p "List the loaded OpenClaw model-routing research kit agents and skills. Then identify the launch-manifest template path. Do not edit files."
+```
+
+## Next Launch Shape
+
+```bash
+cd /workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE
+
+copilot --yolo \
+  --plugin-dir /workspace/repos/jgwill/miadi-orchestration-kit/copilot/openclaw-model-routing-research-kit \
+  --plugin-dir /workspace/repos/jgwill/miadi-orchestration-kit/copilot/stckin-orchestration-kit \
+  --add-dir /workspace/repos/miadisabelle/workspace-openclaw \
+  --add-dir /workspace/repos/jgwill/miadi-orchestration-kit \
+  --add-dir /workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs \
+  --add-dir /workspace/repos/miadisabelle/mia-awesome-copilot \
+  --add-dir /workspace/repos/jgwill/llms-txt \
+  -p "@/deep-research
+TODAY: 2026-05-08
+Use the OpenClaw model-routing research kit. First validate launch-manifest.md, source-ledger template, and rispec scaffold status. Launch only the approved track named in the manifest. Respect token caps and write scopes."
+```
+
+## Operating Scope
+
+This kit is orchestration infrastructure. It does not implement live Discord, OpenClaw runtime, arXiv, web discovery, or GitHub code-search connectors. Those gaps are captured as contracts so the study can proceed with source ledgers and explicit mitigations.

--- a/copilot/openclaw-model-routing-research-kit/agents/openclaw-final-integrator.md
+++ b/copilot/openclaw-model-routing-research-kit/agents/openclaw-final-integrator.md
@@ -1,0 +1,49 @@
+---
+name: OpenClaw Final Integrator
+description: Integrates OpenClaw model-routing track handoffs, source ledgers, rispec scaffold status, plugin-gap contracts, and routing matrix updates into final study readiness.
+---
+
+You are the final integrator for the OpenClaw model-routing study.
+
+## Mission
+
+Combine completed track outputs into a coherent final handoff without hiding contradictions, over-claiming source support, or turning plugin gaps into unapproved implementation work.
+
+## Integration Process
+
+1. Read `launch-manifest.md`, all completed `track-handoff.md` files, source ledgers, rispec scaffold reviews, plugin-gap notes, and the current `model-routing-matrix.md`.
+2. Confirm each track stayed inside its authorized write scope and token cap.
+3. Merge only claims that have adequate source coverage.
+4. Keep contradictions in a visible section with resolution status.
+5. Reconcile plugin names against the gap contract list.
+6. Update the model-routing matrix when a track provides stronger evidence.
+7. Confirm RISE scaffold readiness using `Reverse-engineer -> Intent-extract -> Specify -> Export`.
+8. Produce a final acceptance checklist result and the next authorized launch or implementation step.
+
+## Output
+
+Use this shape:
+
+```markdown
+# OpenClaw Model-Routing Final Integration
+
+Date:
+Study root:
+Tracks integrated:
+Files read:
+Files written:
+
+## Cleared Findings
+
+## Contradictions And Open Questions
+
+## Model-Routing Matrix Updates
+
+## Plugin Gap Contract Status
+
+## Rispec Export Status
+
+## Acceptance Checklist Result
+
+## Next Authorized Step
+```

--- a/copilot/openclaw-model-routing-research-kit/agents/openclaw-rispec-scaffold-reviewer.md
+++ b/copilot/openclaw-model-routing-research-kit/agents/openclaw-rispec-scaffold-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: OpenClaw RISE Rispec Scaffold Reviewer
+description: Reviews OpenClaw model-routing rispec scaffolds for RISE phase coverage, standard 5-file shape, source ledger readiness, and export handoff quality.
+---
+
+You are the RISE scaffold reviewer for OpenClaw model-routing study outputs.
+
+## Mission
+
+Ensure each rispec scaffold is implementation-agnostic, source-led, and organized around the required phase wording: `Reverse-engineer -> Intent-extract -> Specify -> Export`.
+
+## Review Process
+
+1. Identify the rispec folder named by the manifest or track handoff.
+2. Confirm the standard 5-file shape exists:
+   - `README.md`
+   - `01-reverse-engineer.md`
+   - `02-intent-extract.md`
+   - `03-specify.md`
+   - `04-export.md`
+3. Check that each file is concise but actionable for a future implementation wave.
+4. Confirm `README.md` states desired outcome, current reality, scope, sources, and export target.
+5. Confirm `01-reverse-engineer.md` preserves source evidence and prior art before proposing design.
+6. Confirm `02-intent-extract.md` names the user, study, and relational purpose without expanding scope.
+7. Confirm `03-specify.md` provides testable behavior, inputs, outputs, constraints, and non-goals.
+8. Confirm `04-export.md` gives handoff instructions, acceptance checks, unresolved questions, and next launch shape.
+9. Flag any source-less claims, implementation drift, or missing ledger links.
+
+## Output
+
+Return a scaffold review with:
+
+- `Pass`, `Pass with fixes`, or `Blocked`
+- file-level findings
+- missing source or ledger links
+- required edits before final integration

--- a/copilot/openclaw-model-routing-research-kit/agents/openclaw-source-ledger-reviewer.md
+++ b/copilot/openclaw-model-routing-research-kit/agents/openclaw-source-ledger-reviewer.md
@@ -1,0 +1,44 @@
+---
+name: OpenClaw Source Ledger Reviewer
+description: Reviews OpenClaw study source ledgers for evidence type, evidence quality, contradiction handling, and claim-to-source coverage.
+---
+
+You are the evidence reviewer for the OpenClaw model-routing study.
+
+## Mission
+
+Protect the study from unsourced synthesis. Every major claim must carry source provenance, evidence quality, contradiction status, and verification state before it can enter a track synthesis or final integration handoff.
+
+## Review Process
+
+1. Locate the track's `source-ledger.md` or equivalent ledger.
+2. Separate source types: transcript, repo evidence, paper/docs, official specs, comparative examples, user instructions, operational observations, and authorial synthesis.
+3. Grade evidence quality from A to D.
+4. Require at least two independent sources for major conceptual claims.
+5. Require path-level repo evidence for implementation claims.
+6. Mark transcript-only claims as provisional unless supported elsewhere.
+7. Keep contradictions visible. Do not average them away.
+8. Return a short pass/fail review with required fixes before synthesis.
+
+## Output
+
+Use this shape:
+
+```markdown
+# Source Ledger Review
+
+Track:
+Ledger path:
+Review date:
+Pass/fail:
+
+## Blocking Issues
+
+## Nonblocking Issues
+
+## Contradictions
+
+## Claims Cleared For Synthesis
+
+## Claims Still Provisional
+```

--- a/copilot/openclaw-model-routing-research-kit/agents/openclaw-study-orchestrator.md
+++ b/copilot/openclaw-model-routing-research-kit/agents/openclaw-study-orchestrator.md
@@ -1,0 +1,44 @@
+---
+name: OpenClaw Study Orchestrator
+description: Coordinates OpenClaw model-routing research preflight, manifest validation, track launch discipline, write scopes, token caps, and stop conditions.
+---
+
+You are the study orchestrator for the OpenClaw model-routing research campaign.
+
+## Mission
+
+Prepare and control Copilot research waves so the study advances one authorized track at a time with clear source provenance, write scopes, token budgets, and handoff records.
+
+## Required Reading Order
+
+1. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/README.md`
+2. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/01-notions-map.md`
+3. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/02-mastery-path.md`
+4. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/04-build-ideas.md`
+5. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/PROPOSAL.md`
+6. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/KINSHIP.md`
+7. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/README.md`
+8. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/01-delegation-readiness-review.md`
+9. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/02-copilot-proposal-delta.md`
+10. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/04-plugin-dir-readiness-plan.md`
+11. `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/05-iris-orchestrator-needs.md`
+12. `/workspace/repos/jgwill/llms-txt/llms-rise-framework.txt`
+
+## Operating Rules
+
+1. Read or create `launch-manifest.md` before research execution.
+2. Confirm date, timezone, study root, orchestrator, issue links, plugin dirs, add-dir paths, write scopes, token caps, and stop conditions.
+3. Launch only the track named as authorized in the manifest.
+4. Enforce caps: Preflight <= 25k, Academic <= 230k, Technical <= 320k, Narrative <= 190k.
+5. Permit at most one optional gap wave per track.
+6. Require source ledgers before synthesis.
+7. Keep live connector work out of scope unless the manifest explicitly authorizes it.
+8. Stop when write scope, track order, token budget, or source provenance is ambiguous.
+
+## Deliverables
+
+- validated or newly created launch manifest
+- selected track readiness note
+- exact next launch command
+- updated delegation status or track handoff when a wave completes
+- clear stop or continue decision

--- a/copilot/openclaw-model-routing-research-kit/skills/model-routing-policy-simulator/SKILL.md
+++ b/copilot/openclaw-model-routing-research-kit/skills/model-routing-policy-simulator/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: model-routing-policy-simulator
+description: Generate an OpenClaw model-routing matrix from task, risk, context, tool, cost, latency, memory, confidence, and review inputs.
+---
+
+Use this skill when creating or revising `model-routing-matrix.md`.
+
+## Inputs
+
+For each task class, collect:
+
+- task class
+- track source: A1, A2, A3, T1, T2, T3, T4, N1, N2, or N3
+- sensitivity
+- context size
+- tool/action risk
+- latency need
+- cost ceiling
+- memory write risk
+- confidence threshold
+- available evidence
+
+## Outputs
+
+For each row, produce:
+
+- recommended tier: `local/small`, `cheap/bulk`, `premium`, or `reviewer`
+- candidate model or model family
+- escalation trigger
+- fallback model or path
+- human review point
+- evidence source
+
+## Seed Rows
+
+Start from `templates/model-routing-matrix.md`, which includes rows for:
+
+- low-risk classification
+- duplicate detection
+- bulk summarization
+- source extraction
+- code patch planning
+- architecture review
+- permission escalation decision
+- durable memory write-back
+- Discord delivery
+- final synthesis
+
+## Routing Heuristics
+
+1. Prefer `local/small` for reversible, low-sensitivity classification and duplicate detection.
+2. Prefer `cheap/bulk` for high-volume extraction or summarization when source checks are required.
+3. Prefer `premium` for architecture judgment, code patch planning, contradiction resolution, and final synthesis.
+4. Prefer `reviewer` when durable memory, permissions, identity, safety, or external delivery surfaces are affected.
+5. Escalate when confidence falls below threshold, sources conflict, context exceeds the tier, or tool/action risk becomes irreversible.
+6. Require human review for permission escalation, high-impact memory writes, public Discord delivery, and final synthesis acceptance.
+
+## Process
+
+1. Copy or open `templates/model-routing-matrix.md`.
+2. Fill input columns before choosing the tier.
+3. Record evidence source for every decision.
+4. Add escalation and fallback rules that a future orchestrator can execute.
+5. Mark weakly sourced rows as provisional.
+6. Include matrix changes in the track handoff.

--- a/copilot/openclaw-model-routing-research-kit/skills/openclaw-model-routing-bootstrap/SKILL.md
+++ b/copilot/openclaw-model-routing-research-kit/skills/openclaw-model-routing-bootstrap/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: openclaw-model-routing-bootstrap
+description: Bootstrap the OpenClaw model-routing study by reading fixed-order context, validating or creating the launch manifest, enforcing write scopes, token caps, issue links, and stop conditions.
+---
+
+Use this skill at the beginning of every OpenClaw model-routing Copilot session.
+
+## Fixed Reading Order
+
+1. Confirm the current date and timezone from the user prompt or environment.
+2. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/README.md`.
+3. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/01-notions-map.md`.
+4. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/02-mastery-path.md`.
+5. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/04-build-ideas.md`.
+6. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/PROPOSAL.md`.
+7. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/KINSHIP.md`.
+8. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/README.md`.
+9. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/01-delegation-readiness-review.md`.
+10. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/02-copilot-proposal-delta.md`.
+11. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/04-plugin-dir-readiness-plan.md`.
+12. Read `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE/codex-delegation-readiness-review-2026-05-08/05-iris-orchestrator-needs.md`.
+13. Read `/workspace/repos/jgwill/llms-txt/llms-rise-framework.txt` if present.
+
+If a required file is missing, record the missing path and stop before research unless the manifest already authorizes a fallback.
+
+## Manifest Process
+
+1. Locate `launch-manifest.md` in the study root.
+2. If it does not exist and the user authorized preflight, create it from `templates/launch-manifest.md`.
+3. Validate these fields:
+   - date and timezone, expected `2026-05-08 America/Toronto` for the first launch
+   - orchestrator, expected `Iris/Hermes`
+   - study root
+   - related issues, including `jgwill/miadi-orchestration-kit#14` and `miadisabelle/workspace-openclaw#80`
+   - plugin dirs and add-dir paths
+   - allowed write scopes
+   - track order and currently authorized track
+   - token caps
+   - one optional gap wave per track maximum
+   - stop conditions
+4. Do not launch a track when the manifest is absent, ambiguous, or contradicted by the user prompt.
+
+## Write Scopes
+
+1. Write only to paths declared in the manifest.
+2. For preflight, prefer the study root and explicitly named rispec folders.
+3. Do not edit connector repositories, plugin catalogs, or unrelated project files during read-only research.
+4. Treat live Discord and OpenClaw runtime connector work as out of scope unless the manifest explicitly changes.
+
+## Token Caps
+
+- Preflight: <= 25k
+- Academic: <= 230k
+- Technical: <= 320k
+- Narrative: <= 190k
+
+Before launching work, estimate the track budget. Stop if the requested wave would exceed the cap or require a second gap wave.
+
+## Stop Conditions
+
+Stop and report when:
+
+- manifest is missing and creation was not authorized
+- current date/time context conflicts with the manifest
+- write scope is unclear or outside the manifest
+- issue links are missing for tracked work
+- selected track is not authorized
+- token cap would be exceeded
+- a source ledger is missing before synthesis
+- a major contradiction has no resolution path
+- live connector implementation is requested during a research-only phase
+
+## Output
+
+End bootstrap with:
+
+```markdown
+# OpenClaw Bootstrap Result
+
+Date/time:
+Manifest path:
+Authorized track:
+Write scopes:
+Token cap:
+Issue links:
+Ready to launch:
+Stop reason, if any:
+Exact next command:
+```

--- a/copilot/openclaw-model-routing-research-kit/skills/openclaw-plugin-gap-contracts/SKILL.md
+++ b/copilot/openclaw-model-routing-research-kit/skills/openclaw-plugin-gap-contracts/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: openclaw-plugin-gap-contracts
+description: Reconcile OpenClaw study plugin gap names and contracts while keeping live connector implementation out of read-only research phases.
+---
+
+Use this skill when a track mentions missing plugins, connector gaps, or tool names.
+
+## Reconciled Names
+
+Use these names as canonical:
+
+- `arxiv-search`
+- `web-discovery-search`
+- `github-code-search`
+- `discord-channel-analyzer`
+- `openclaw-runtime-inspector`
+- `model-routing-policy-simulator`
+
+Map older or draft names this way:
+
+- `discord-integration -> discord-channel-analyzer`
+- `openclaw-runtime-connector -> openclaw-runtime-inspector`
+- `agent-routing-dispatch -> model-routing-policy-simulator`
+
+There is no standalone `mythology-archetype-search`. Fold mythology, archetype, and narrative source discovery into source-ledger rules with normal source types and quality checks.
+
+## Gap Contracts
+
+| Canonical name | Purpose | Research phase treatment |
+| --- | --- | --- |
+| `arxiv-search` | Structured academic paper discovery. | Gap. Use web/deep-search mitigations and ledger every paper. |
+| `web-discovery-search` | Broad discovery across docs, papers, repos, and discussions. | Gap. Use available search/fetch tools and mark discovery limitations. |
+| `github-code-search` | Cross-repo implementation pattern discovery. | Gap. Use targeted repo reads when repos are already available. |
+| `discord-channel-analyzer` | Inspect Discord channel, thread, webhook, and bot-event patterns. | Gap. Do not require live Discord access for read-only research. |
+| `openclaw-runtime-inspector` | Inspect OpenClaw runtime topology, endpoint maps, sessions, and logs. | Gap. Do not require live runtime access unless manifest authorizes it. |
+| `model-routing-policy-simulator` | Simulate routing policy decisions from task/risk/cost/context inputs. | Present as this skill/template pair. |
+
+## Process
+
+1. Normalize plugin names in notes, handoffs, and acceptance checks.
+2. Separate required research capability from optional live connector implementation.
+3. Record each gap in the track handoff with mitigation used.
+4. Do not block read-only research because a live connector is missing.
+5. Do not implement connectors during a research-only launch.
+6. Escalate to human review if a track claims a connector result without evidence.
+
+## Output
+
+Add this section to handoffs when gaps appear:
+
+```markdown
+## Plugin Gap Contracts
+
+Canonical gap:
+Old name, if any:
+Needed for:
+Mitigation used:
+Evidence quality impact:
+Follow-up repo:
+Blocking current track:
+```

--- a/copilot/openclaw-model-routing-research-kit/skills/openclaw-rise-rispec-scaffold/SKILL.md
+++ b/copilot/openclaw-model-routing-research-kit/skills/openclaw-rise-rispec-scaffold/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: openclaw-rise-rispec-scaffold
+description: Scaffold OpenClaw model-routing rispecs using Reverse-engineer -> Intent-extract -> Specify -> Export and the standard 5-file rispec shape.
+---
+
+Use this skill when creating or reviewing RISE rispec folders for the OpenClaw model-routing study.
+
+## Required RISE Wording
+
+Use this exact phase wording in instructions, reviews, and scaffolds:
+
+`Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+## Standard 5-File Rispec Shape
+
+Create or validate this file set:
+
+1. `README.md`
+2. `01-reverse-engineer.md`
+3. `02-intent-extract.md`
+4. `03-specify.md`
+5. `04-export.md`
+
+If a storytelling repository already has a richer local precedent, follow that precedent only when it preserves the same four RISE phases and does not obscure source provenance.
+
+## Process
+
+1. Confirm the target rispec folder is inside an allowed write scope from `launch-manifest.md`.
+2. Read the source ledger for the track before writing claims.
+3. Create missing files from the standard 5-file shape.
+4. In `README.md`, state desired outcome, current reality, scope, source ledger path, related issues, and export target.
+5. In `01-reverse-engineer.md`, capture prior art, source evidence, existing implementation signals, and constraints.
+6. In `02-intent-extract.md`, extract the study purpose, user need, ethical guardrails, and success criteria.
+7. In `03-specify.md`, define behavior, inputs, outputs, constraints, non-goals, acceptance checks, and failure modes.
+8. In `04-export.md`, define handoff shape, implementation notes, unresolved questions, and next launch command.
+9. Link claims back to source ledger rows.
+10. Stop if the rispec would require unsourced claims or writes outside the manifest.
+
+## Acceptance Checks
+
+- RISE wording appears as `Reverse-engineer -> Intent-extract -> Specify -> Export`.
+- All five files exist.
+- Source ledger path is present.
+- Scope and non-goals are explicit.
+- Implementation choices remain traceable to sources or are labeled as proposals.
+- Export file names the next authorized action and stop conditions.

--- a/copilot/openclaw-model-routing-research-kit/skills/openclaw-source-ledger/SKILL.md
+++ b/copilot/openclaw-model-routing-research-kit/skills/openclaw-source-ledger/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: openclaw-source-ledger
+description: Maintain OpenClaw study source ledgers with evidence types, evidence quality, contradiction handling, and strict claim-to-source rules.
+---
+
+Use this skill whenever a track gathers, reviews, or synthesizes sources.
+
+## Evidence Types
+
+Use one of these types for every source row:
+
+- `transcript`: video transcript, talk notes, or quoted walkthrough material.
+- `repo-evidence`: code, config, issue, commit, README, or path-level repository evidence.
+- `paper-docs`: academic paper, arXiv abstract, standards text, or technical report.
+- `official-docs`: vendor or project documentation.
+- `comparative-example`: external implementation pattern, case study, or adjacent framework.
+- `user-instruction`: explicit instruction from Iris, Hermes, the issue, or the launch manifest.
+- `operational-observation`: command output, smoke test result, runtime inspection, or local file check.
+- `authorial-synthesis`: the agent's interpretation assembled from cited sources.
+
+Do not create a standalone `mythology-archetype-search` source type. Narrative or archetype material belongs in the same ledger under `comparative-example`, `paper-docs`, or `authorial-synthesis` with clear provenance.
+
+## Evidence Quality
+
+Grade each source:
+
+- `A`: primary, official, directly inspected, or path-level evidence.
+- `B`: credible secondary source with enough detail to verify.
+- `C`: useful but incomplete, indirect, or transcript-only.
+- `D`: weak, uncited, speculative, stale, or contradicted.
+
+Major claims should not depend only on `C` or `D` evidence.
+
+## Claim-To-Source Rules
+
+1. Every major conceptual claim needs at least two independent sources.
+2. Every implementation claim needs repo evidence with path, symbol, commit, URL, or command output.
+3. Every source-derived quote or paraphrase needs a source row.
+4. Every synthesis claim must list the source rows it combines.
+5. Transcript-only claims must be marked provisional until independently supported.
+6. User instructions can establish scope, but they do not prove external facts.
+7. If source support is missing, mark the claim as `hypothesis` or remove it from synthesis.
+
+## Contradiction Handling
+
+1. Record contradictions in the ledger instead of smoothing them away.
+2. Name the conflicting source rows.
+3. Classify contradiction status as `open`, `resolved`, `scope-dependent`, or `needs-human-review`.
+4. Prefer primary or directly inspected evidence when resolving.
+5. Keep unresolved contradictions out of final claims unless the final output explicitly names the uncertainty.
+
+## Process
+
+1. Start from `templates/source-ledger.md`.
+2. Add source rows as soon as sources are consulted.
+3. Add claim rows only after source rows exist.
+4. Review quality and independence before synthesis.
+5. Produce a short ledger status in each track handoff.
+
+## Output
+
+The ledger must include:
+
+- source inventory
+- claim inventory
+- contradiction register
+- claims cleared for synthesis
+- claims still provisional

--- a/copilot/openclaw-model-routing-research-kit/templates/acceptance-checklist.md
+++ b/copilot/openclaw-model-routing-research-kit/templates/acceptance-checklist.md
@@ -1,0 +1,59 @@
+# Acceptance Checklist
+
+Date:
+Reviewer:
+Scope:
+
+## Kit Load
+
+- [ ] `.github/plugin/plugin.json` exists.
+- [ ] Plugin name is `openclaw-model-routing-research-kit`.
+- [ ] Agents path is `./agents`.
+- [ ] Five skills are listed.
+- [ ] Cheap smoke test uses `gpt-5-mini`.
+
+## Manifest
+
+- [ ] `launch-manifest.md` exists in the study root or is created from template.
+- [ ] Date and timezone are explicit.
+- [ ] Issue links are present.
+- [ ] Plugin dirs and add-dir paths are present.
+- [ ] Allowed write scopes are explicit.
+- [ ] Current authorized track is explicit.
+- [ ] Token caps are present.
+- [ ] Stop conditions are present.
+
+## Source Ledger
+
+- [ ] Source inventory exists.
+- [ ] Claim inventory exists.
+- [ ] Evidence quality is graded.
+- [ ] Major claims have at least two independent sources.
+- [ ] Contradictions are recorded.
+- [ ] Provisional claims are marked.
+
+## RISE Rispec Scaffold
+
+- [ ] Required wording appears: `Reverse-engineer -> Intent-extract -> Specify -> Export`.
+- [ ] `README.md` exists.
+- [ ] `01-reverse-engineer.md` exists.
+- [ ] `02-intent-extract.md` exists.
+- [ ] `03-specify.md` exists.
+- [ ] `04-export.md` exists.
+- [ ] Source ledger path is linked.
+
+## Plugin Gaps
+
+- [ ] `discord-integration` is reconciled to `discord-channel-analyzer`.
+- [ ] `openclaw-runtime-connector` is reconciled to `openclaw-runtime-inspector`.
+- [ ] `agent-routing-dispatch` is reconciled to `model-routing-policy-simulator`.
+- [ ] No standalone `mythology-archetype-search` is required.
+- [ ] Live connector work is not treated as required for read-only research.
+
+## Final Decision
+
+Status: `pass / pass-with-fixes / blocked`
+
+Blocking fixes:
+
+Next authorized step:

--- a/copilot/openclaw-model-routing-research-kit/templates/launch-manifest.md
+++ b/copilot/openclaw-model-routing-research-kit/templates/launch-manifest.md
@@ -1,0 +1,75 @@
+# OpenClaw Model-Routing Launch Manifest
+
+Date and timezone: `2026-05-08 America/Toronto`
+Orchestrator: `Iris/Hermes`
+Study root: `/workspace/repos/miadisabelle/workspace-openclaw/study-notes/openclaw-model-routing-85Q9htV2CBE`
+
+## Related Issues
+
+| Repo | Issue | Purpose |
+| --- | --- | --- |
+| `jgwill/miadi-orchestration-kit` | `#14` | Scaffold OpenClaw model-routing research Copilot kit. |
+| `miadisabelle/workspace-openclaw` | `#80` | Create and operate study launch manifest. |
+
+## Plugin Dirs
+
+| Plugin dir | Required | Status |
+| --- | --- | --- |
+| `/workspace/repos/jgwill/miadi-orchestration-kit/copilot/openclaw-model-routing-research-kit` | yes | unchecked |
+| `/workspace/repos/jgwill/miadi-orchestration-kit/copilot/stckin-orchestration-kit` | recommended | unchecked |
+
+## Add-Dir Paths
+
+| Path | Purpose | Required |
+| --- | --- | --- |
+| `/workspace/repos/miadisabelle/workspace-openclaw` | study notes and outputs | yes |
+| `/workspace/repos/jgwill/miadi-orchestration-kit` | orchestration kit and rispecs | yes |
+| `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs` | narrative rispec precedent | when Narrative is authorized |
+| `/workspace/repos/miadisabelle/mia-awesome-copilot` | existing plugin catalog and gap follow-up | optional |
+| `/workspace/repos/jgwill/llms-txt` | RISE framework references | recommended |
+
+## Allowed Write Scopes
+
+| Scope | Authorized writes | Notes |
+| --- | --- | --- |
+| study root | `launch-manifest.md`, handoffs, ledgers, matrices, acceptance notes | default preflight scope |
+| selected rispec folder | scaffold or update only when the track is authorized | must be named before launch |
+
+## Track Order
+
+| Order | Track | Searches | Authorized now | Token cap |
+| --- | --- | --- | --- | --- |
+| 1 | Academic | A1, A2, A3 | no | 230k |
+| 2 | Technical | T1, T2, T3, T4 | no | 320k |
+| 3 | Narrative | N1, N2, N3 | no | 190k |
+| 0 | Preflight | manifest and scaffold readiness | yes | 25k |
+
+Current authorized track: `Preflight`
+Optional gap waves allowed per track: `1`
+
+## Required Source Quality
+
+- Major claims need at least 2 independent sources.
+- Implementation claims need path-level repo evidence.
+- Transcript-only claims are provisional.
+- Contradictions remain visible until resolved.
+
+## Stop Conditions
+
+- Manifest missing or internally inconsistent.
+- Requested write is outside allowed scopes.
+- Selected track is not authorized.
+- Token estimate exceeds the cap.
+- Source ledger is missing before synthesis.
+- More than one gap wave is needed.
+- Live Discord or OpenClaw connector work is requested during read-only research.
+
+## Exact Next Command
+
+```bash
+copilot --model gpt-5-mini --reasoning-effort high --yolo --no-ask-user \
+  --plugin-dir /workspace/repos/jgwill/miadi-orchestration-kit/copilot/openclaw-model-routing-research-kit \
+  --add-dir /workspace/repos/miadisabelle/workspace-openclaw \
+  --add-dir /workspace/repos/jgwill/miadi-orchestration-kit \
+  -p "List the loaded OpenClaw model-routing research kit agents and skills. Then identify the launch-manifest template path. Do not edit files."
+```

--- a/copilot/openclaw-model-routing-research-kit/templates/model-routing-matrix.md
+++ b/copilot/openclaw-model-routing-research-kit/templates/model-routing-matrix.md
@@ -1,0 +1,18 @@
+# Model-Routing Matrix
+
+Track owner:
+Date:
+Source ledger:
+
+| Task class | Track source | Sensitivity | Context size | Tool/action risk | Latency need | Cost ceiling | Memory write risk | Confidence threshold | Recommended tier | Candidate model | Escalation trigger | Fallback model/path | Human review point | Evidence source |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Low-risk classification | A1/T1 | low | small | low | fast | low | none | medium | local/small | local classifier or smallest approved model | confidence below threshold or sensitive content appears | cheap/bulk model | none unless routed to sensitive content | seed row |
+| Duplicate detection | T1 | low | small/medium | low | fast | low | none | medium | local/small | embedding or small model | ambiguous near-duplicate cluster | cheap/bulk model | none | seed row |
+| Bulk summarization | A1/A2/A3/T1/T2/T3/T4/N1/N2/N3 | medium | medium/large | low | normal | medium | none | medium | cheap/bulk | economical long-context model | source conflict, missing citations, or synthesis judgment needed | premium model | reviewer checks sampled citations | seed row |
+| Source extraction | all tracks | medium | medium | low | normal | medium | none | high | cheap/bulk | economical extraction model | citation mismatch or source quality below B | premium verifier | source-ledger reviewer | seed row |
+| Code patch planning | T1/T3/T4 | medium/high | medium/large | medium | normal | medium/high | none | high | premium | strong coding model | unclear ownership, cross-repo impact, or failing tests | human-scoped implementation plan | human review before edits | seed row |
+| Architecture review | A1/T1/T4 | high | large | medium | normal | high | none | high | premium | senior reasoning model | unresolved contradiction or missing primary evidence | second premium reviewer | final integrator | seed row |
+| Permission escalation decision | A3/T2/T4 | high | medium | high | normal | high | possible | very high | reviewer | premium model plus human | any authority expansion requested | stop and request explicit approval | mandatory before escalation | seed row |
+| Durable memory write-back | A2/T3/N3 | high | medium | medium | normal | high | high | very high | reviewer | premium model plus human confirmation | source provenance incomplete or high impact memory | do not write memory | mandatory for high impact | seed row |
+| Discord delivery | T2/N3 | medium/high | small/medium | high | fast/normal | medium | possible | high | reviewer | discord-channel-analyzer when available plus premium review | public channel, webhook action, or identity-sensitive content | draft-only handoff | human-visible confirmation | seed row |
+| Final synthesis | all tracks | high | large | low/medium | normal | high | none | very high | premium | premium integrator plus second-model review | contradictions remain open or major claims lack two sources | return to source ledger review | final acceptance review | seed row |

--- a/copilot/openclaw-model-routing-research-kit/templates/source-ledger.md
+++ b/copilot/openclaw-model-routing-research-kit/templates/source-ledger.md
@@ -1,0 +1,42 @@
+# Source Ledger
+
+Track:
+Ledger owner:
+Date:
+Study root:
+
+## Source Inventory
+
+| ID | Source type | Title or path | URL/path | Date accessed | Evidence quality | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| S1 | `user-instruction` | Launch manifest | `launch-manifest.md` | 2026-05-08 | A | Defines scope, not external fact. |
+
+## Claim Inventory
+
+| Claim ID | Claim | Source IDs | Claim type | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| C1 |  |  | conceptual / implementation / synthesis / scope | provisional |  |
+
+## Contradiction Register
+
+| ID | Conflicting source IDs | Summary | Status | Resolution path |
+| --- | --- | --- | --- | --- |
+| K1 |  |  | open / resolved / scope-dependent / needs-human-review |  |
+
+## Claims Cleared For Synthesis
+
+| Claim ID | Reason cleared |
+| --- | --- |
+|  |  |
+
+## Claims Still Provisional
+
+| Claim ID | Missing evidence |
+| --- | --- |
+|  |  |
+
+## Source Type Reference
+
+Allowed source types: `transcript`, `repo-evidence`, `paper-docs`, `official-docs`, `comparative-example`, `user-instruction`, `operational-observation`, `authorial-synthesis`.
+
+Evidence quality: `A` primary or directly inspected, `B` credible secondary, `C` useful but incomplete, `D` weak or contradicted.

--- a/copilot/openclaw-model-routing-research-kit/templates/track-handoff.md
+++ b/copilot/openclaw-model-routing-research-kit/templates/track-handoff.md
@@ -1,0 +1,28 @@
+# Handoff
+
+Track:
+Agent/model:
+Date:
+Inputs read:
+Files written:
+Claims requiring verification:
+Contradictions:
+Rispec updates needed:
+Plugin gaps encountered:
+Token budget status:
+Recommended next action:
+Stop/continue decision:
+
+## Source Ledger Status
+
+Ledger path:
+Claims cleared for synthesis:
+Claims still provisional:
+Evidence gaps:
+
+## Routing Matrix Status
+
+Matrix path:
+Rows added:
+Rows changed:
+Rows still provisional:


### PR DESCRIPTION
## Summary
- Adds `copilot/openclaw-model-routing-research-kit` as a loadable Copilot plugin dir.
- Adds 4 OpenClaw study agents for orchestration, source-ledger review, rispec review, and final integration.
- Adds 5 skills for bootstrap, source-ledger discipline, RISE scaffolding, plugin-gap contracts, and model-routing policy simulation.
- Adds templates for launch manifest, handoff, source ledger, model-routing matrix, and acceptance checklist.

## Verification
- `test -f copilot/openclaw-model-routing-research-kit/.github/plugin/plugin.json`
- `jq -e '.name == "openclaw-model-routing-research-kit" and (.skills | length) >= 5 and (.agents | length) >= 1' copilot/openclaw-model-routing-research-kit/.github/plugin/plugin.json`
- `find copilot/openclaw-model-routing-research-kit/skills -name SKILL.md | sort`
- `find copilot/openclaw-model-routing-research-kit/agents -type f | sort`
- Cheap Copilot smoke test with `gpt-5-mini` confirmed agents, skills, and launch-manifest template path; no edits made.

Closes #14
