### PR TITLE
docs(rispecs): scaffold OpenClaw model-routing specs

### DIFF
--- a/rispecs/agent-memory-provenance-framework/01-reverse-engineer.md
+++ b/rispecs/agent-memory-provenance-framework/01-reverse-engineer.md
@@ -1,0 +1,74 @@
+# Reverse-engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage reconstructs what the OpenClaw model-routing study evidence actually shows about memory provenance, trust levels, metadata, scope, and write-back gates.
+
+It does not decide the final schema. It prepares evidence for `02-intent.md`.
+
+## Source surfaces to inspect later
+
+| Surface | Evidence to extract | Minimum handling |
+| --- | --- | --- |
+| Study manifest | Required memory metadata and write-back gate language | Treat as control-plane evidence. |
+| Study proposal | A2/T3 scope, trust-tier claims, schema brief | Treat as planning evidence, not final findings. |
+| Transcript and study notes | Claims about user-owned memory and confirmation | Mark transcript-only until corroborated. |
+| Repo path evidence | Memory files, schema code, persistence layers, merge tools, instruction updates | Require exact path and observed behavior. |
+| External sources | provenance, audit, RAG citation, agent memory literature or docs | Keep terminology source-classed. |
+| Human confirmation | explicit user or operator decision about a memory item | Record as confirmation evidence, not inference. |
+
+## Evidence-backed observation shape
+
+Each reconstructed observation should include:
+
+- claim text,
+- memory state affected,
+- source class and exact pointer,
+- evidence status,
+- candidate field or transition,
+- confidence,
+- missing corroboration,
+- whether it can affect write-back.
+
+## Trust states to reconstruct
+
+| State | What to look for | Boundary |
+| --- | --- | --- |
+| `observed` | Behavior or source text directly observed by an agent. | Observation is not confirmation. |
+| `inferred` | A conclusion derived from context or repeated behavior. | Must carry lower confidence and cannot overwrite confirmation. |
+| `user-confirmed` | A human explicitly confirms, corrects, or bounds the memory. | Requires source pointer to the confirming act. |
+| `contradicted` | A later source conflicts with a stored memory. | Must remain visible until resolved. |
+| `deprecated` | A memory is no longer valid but should remain auditable. | Do not delete without retention rule. |
+
+## Required metadata evidence
+
+Future waves must determine source support for:
+
+- `source`,
+- `observed_at`,
+- `confidence`,
+- `status`,
+- `scope`,
+- `related_task`,
+- `user_confirmed`,
+- optional `confirmed_at`,
+- optional `expires_at`,
+- optional contradiction or supersession pointer.
+
+## Boundaries
+
+- Do not treat chat history as trusted memory without provenance.
+- Do not promote an inferred preference into user-confirmed memory.
+- Do not collapse source, confidence, and status into one field.
+- Do not write memory during scaffold work.
+- Do not run Academic or Technical research from this scaffold.
+
+## Handoff shape
+
+The handoff to `02-intent.md` should contain:
+
+- supported trust-state vocabulary,
+- candidate metadata fields with source status,
+- write-back risks,
+- unresolved contradictions,
+- claims that must remain provisional.

--- a/rispecs/agent-memory-provenance-framework/02-intent.md
+++ b/rispecs/agent-memory-provenance-framework/02-intent.md
@@ -1,0 +1,68 @@
+# Intent-extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines the structural tension for memory provenance in the OpenClaw model-routing study.
+
+## Desired outcome
+
+Future agents can carry useful memory across sessions and model swaps without turning vague context into false authority. Each memory record remains auditable through source, observed time, confidence, status, scope, related task, and explicit human confirmation state before any write-back.
+
+## Current reality
+
+The study points toward persistent, user-owned memory, but the starting conditions are mixed:
+
+- memory may be observed, inferred, or user-confirmed,
+- provider memory and local memory can blur,
+- session notes can look more authoritative than they are,
+- later agents may consume memory without seeing its source or confidence,
+- write-back can silently promote weak claims.
+
+## Structural tension
+
+| Current reality | Desired outcome | Advancing move |
+| --- | --- | --- |
+| Memory often appears as untyped context. | Memory records expose trust state and provenance. | Require metadata before write-back or reuse. |
+| Inference can masquerade as confirmation. | Human confirmation is explicit and auditable. | Separate `inferred` from `user-confirmed` in status and ledger. |
+| Model swaps can carry stale assumptions forward. | Memory survives model swaps only through scoped, reviewable records. | Attach scope, related task, confidence, and observed time. |
+| Contradictions can be overwritten. | Contradictions remain visible until resolved. | Add contradiction status and review handoff. |
+
+## Creative advancement scenarios
+
+### Scenario: preserve an observed preference
+
+**Desired Outcome:** A future agent can remember an observed preference without overstating trust.
+
+**Current Reality:** The preference may come from behavior, not direct user confirmation.
+
+**Natural Progression:** The memory is recorded as `observed`, given a source pointer, `observed_at`, confidence, scope, and related task.
+
+**Resolution:** The record can guide low-risk behavior while still inviting confirmation before higher-impact use.
+
+### Scenario: promote confirmed memory
+
+**Desired Outcome:** A user-confirmed memory can safely guide future sessions.
+
+**Current Reality:** The system needs to distinguish confirmation from inference and transcript summary.
+
+**Natural Progression:** A confirmation event updates `user_confirmed`, status, confidence, and source pointer while preserving prior history.
+
+**Resolution:** Future agents can rely on the memory within its declared scope and still audit how it became trusted.
+
+## Non-goals
+
+- Do not implement a memory database.
+- Do not write or migrate memories.
+- Do not decide production retention policy.
+- Do not treat memory as identity or narrative framing; use the storytelling rispecs for that later.
+- Do not run Academic, Technical, Narrative, or final research.
+
+## Handoff shape
+
+The handoff to `03-specify.md` should provide:
+
+- approved trust-state vocabulary,
+- required metadata fields,
+- write-back risk model,
+- contradiction handling intent,
+- evidence gaps that block schema promotion.

--- a/rispecs/agent-memory-provenance-framework/03-specify.md
+++ b/rispecs/agent-memory-provenance-framework/03-specify.md
@@ -1,0 +1,75 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines the control-plane contract for memory provenance, schema proposals, and write-back gates.
+
+## Required reading order
+
+1. This README.
+2. `05-source-ledger.md`.
+3. `01-reverse-engineer.md`.
+4. `02-intent.md`.
+5. Active A2 or T3 findings only if the study manifest authorizes the track.
+6. Source evidence named by the active ledger rows.
+
+## Memory record contract
+
+Every proposed memory record shape must include or explicitly reject with rationale:
+
+| Field | Requirement |
+| --- | --- |
+| `content` | The memory claim itself, phrased narrowly. |
+| `source` | Exact source pointer or confirmation event. |
+| `observed_at` | When the source was observed. |
+| `confidence` | Low, medium, or high with evidence reason. |
+| `status` | `observed`, `inferred`, `user-confirmed`, `contradicted`, `deprecated`, or another ledger-backed status. |
+| `scope` | Where the memory may be used. |
+| `related_task` | Study, issue, workflow, or user task that produced the memory. |
+| `user_confirmed` | Boolean or richer confirmation object; must not be inferred. |
+
+## Write-back gates
+
+| Gate | Required before passing |
+| --- | --- |
+| Observation gate | Source pointer, `observed_at`, scope, and status are present. |
+| Inference gate | Inference rationale and confidence are recorded; no overwrite of confirmed data. |
+| Confirmation gate | Explicit human confirmation source is recorded. |
+| Contradiction gate | Conflicting claims are linked and review owner is named. |
+| Export gate | Ledger row exists and promotion status is clear. |
+
+## Status transition rules
+
+- `observed` may become `inferred` only with rationale and confidence.
+- `observed` or `inferred` may become `user-confirmed` only through explicit human confirmation.
+- Any state may become `contradicted` when a conflicting source appears.
+- `contradicted` may not become `user-confirmed` until the contradiction is resolved.
+- `deprecated` records remain auditable unless a separate retention rule authorizes removal.
+
+## Lane contract
+
+| Lane | Owns | Exit artefact |
+| --- | --- | --- |
+| A2 provenance lane | Trust vocabulary and provenance concepts | Vocabulary map with evidence status. |
+| T3 schema lane | Fields, transitions, merge behavior, write-back gates | Schema proposal with ledger pointers. |
+| Review lane | Unsupported trust claims and unsafe promotions | Revision list and stop conditions. |
+| Ledger lane | Claim status and contradiction tracking | Updated `05-source-ledger.md`. |
+
+## Stop conditions
+
+- A write-back is proposed without source, status, confidence, scope, and confirmation state.
+- An inferred claim is treated as user-confirmed.
+- A schema field is promoted without evidence or explicit provisional status.
+- A repo behavior claim lacks path-level evidence.
+- The active track is not authorized by the launch manifest.
+
+## Handoff shape
+
+The handoff to `04-export.md` should include:
+
+- proposed schema,
+- field-level evidence status,
+- transition rules,
+- write-back gates,
+- unresolved contradictions,
+- audit prompts for memory promotion.

--- a/rispecs/agent-memory-provenance-framework/04-export.md
+++ b/rispecs/agent-memory-provenance-framework/04-export.md
@@ -1,0 +1,68 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines how memory provenance work is launched, resumed, audited, and handed off after the study manifest authorizes a track.
+
+## Launch prompt shape
+
+Use this only after the active manifest authorizes A2 or T3:
+
+```text
+Read the OpenClaw model-routing study launch manifest, this rispec folder, and the current source ledger first.
+
+Operate only on the authorized track.
+Use the RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export.
+
+Goal:
+- For A2, produce provenance and trust vocabulary with source status.
+- For T3, produce schema, transition, and write-back gate proposals.
+
+Required handoff:
+- exact sources read,
+- source status for each memory field and trust rule,
+- schema or vocabulary outputs,
+- contradictions,
+- unsupported claims that remain provisional,
+- no memory write-back unless separately authorized.
+```
+
+## Resume pattern
+
+On resume:
+
+1. Confirm manifest authorization.
+2. Read `05-source-ledger.md` before any synthesis.
+3. Read the last handoff or track findings.
+4. Continue only the next incomplete lane.
+5. Do not consume memory records that lack status and source.
+
+## Audit pattern
+
+An audit pass should verify:
+
+- every schema field has a ledger row,
+- observed, inferred, and user-confirmed states are separated,
+- `source`, `observed_at`, `confidence`, `status`, `scope`, `related_task`, and `user_confirmed` are present before promotion,
+- transcript-only memory claims remain provisional,
+- repo behavior claims have path evidence,
+- contradictions remain visible,
+- no memory was written during scaffold work.
+
+## Export destinations
+
+| Destination | Allowed content | Required status |
+| --- | --- | --- |
+| A2 findings | Provenance vocabulary and trust model | Ledger-backed or provisional. |
+| T3 findings | Schema, transitions, merge and write-back gates | Ledger-backed with repo path evidence for observed behavior. |
+| Memory tooling work | Candidate schema only | Separate authorization required before writes. |
+| Study handoff | Blockers, evidence gaps, next safe instruction | No final synthesis unless authorized. |
+
+## Handoff checklist
+
+- Source ledger updated.
+- Field-level evidence recorded.
+- Write-back gates named.
+- Contradictions preserved.
+- Confirmation source requirements explicit.
+- Next track entry point names the manifest authorization requirement.

--- a/rispecs/agent-memory-provenance-framework/05-source-ledger.md
+++ b/rispecs/agent-memory-provenance-framework/05-source-ledger.md
@@ -1,0 +1,68 @@
+# Agent Memory Provenance Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger preserves provenance for memory trust, schema, and write-back claims in the OpenClaw model-routing study.
+
+## Related issues
+
+- `miadisabelle/workspace-openclaw#80`
+- `jgwill/miadi-orchestration-kit#15`
+
+## Ledger rules
+
+| Status | Meaning | Promotion rule |
+| --- | --- | --- |
+| Evidence | Directly supported by a cited source surface. | Can be used if the source pointer is specific. |
+| Repo path evidence | Supported by code, config, docs, or test paths in a repo. | Required for schema or write-back behavior claims. |
+| Transcript-only claim | Present in transcript or video notes only. | Keep provisional until corroborated. |
+| Provisional claim | Plausible but missing sufficient support. | Name missing evidence before reuse. |
+| Contradiction | Sources conflict or imply incompatible memory rules. | Preserve until a review lane resolves it. |
+
+## Source classes
+
+| Source class | Examples | Use |
+| --- | --- | --- |
+| Study control | `launch-manifest.md`, `PROPOSAL.md` | Scope, required metadata, track boundaries. |
+| Transcript and notes | source video transcript, timestamped notes | Candidate claims about memory ownership or trust. |
+| Repo path evidence | memory schemas, stores, merge tools, instruction files | Observed implementation behavior. |
+| External sources | provenance papers, RAG docs, memory-system references | Vocabulary and comparable patterns. |
+| Human confirmation | explicit user correction, confirmation, or denial | Promotion to `user-confirmed`. |
+
+## Seed entries
+
+| ID | Claim | Status | Evidence pointer | Notes |
+| --- | --- | --- | --- | --- |
+| AMP-001 | This rispec serves A2 and T3 for the OpenClaw model-routing study. | Evidence | Study proposal section "Rispec Scaffold Index"; issue `jgwill/miadi-orchestration-kit#15` context. | Control-plane scope only. |
+| AMP-002 | Required RISE wording is `Reverse-engineer -> Intent-extract -> Specify -> Export`. | Evidence | Study launch manifest "RISE Wording (Required Exactly)". | Must remain exact. |
+| AMP-003 | Memory candidates must carry `source`, `observed_at`, `confidence`, `status`, `scope`, `related_task`, and `user_confirmed` before write-back. | Evidence | Study launch manifest required source quality. | Required by this scaffold. |
+| AMP-004 | Trust states include observed, inferred, and user-confirmed candidates. | Provisional claim | Study proposal context summary and memory rispec brief. | Needs source support before final schema. |
+| AMP-005 | Repo path evidence is required before write-back behavior is treated as observed. | Evidence | Study launch manifest source-quality rules. | Applies to T3. |
+
+## Claim intake table
+
+| ID | Claim | Source class | Exact pointer | Status | Confidence | Related track | Missing evidence | Resolution notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<id>` | `<claim>` | `<class>` | `<path/url/time>` | `<status>` | `<low/medium/high>` | `<A2/T3>` | `<needed support>` | `<review result>` |
+
+## Memory field ledger
+
+| Field | Purpose | Evidence pointer | Status | Write-back gate |
+| --- | --- | --- | --- | --- |
+| `source` | Provenance for the memory claim. | AMP-003 | Evidence | Required. |
+| `observed_at` | Time the source was observed. | AMP-003 | Evidence | Required. |
+| `confidence` | Trust estimate. | AMP-003 | Evidence | Required. |
+| `status` | Trust state. | AMP-003 | Evidence | Required. |
+| `scope` | Allowed use boundary. | AMP-003 | Evidence | Required. |
+| `related_task` | Producing task or workflow. | AMP-003 | Evidence | Required. |
+| `user_confirmed` | Explicit human confirmation state. | AMP-003 | Evidence | Required. |
+
+## Contradiction log
+
+| ID | Conflicting claims | Sources | Current handling | Review owner |
+| --- | --- | --- | --- | --- |
+| `<id>` | `<claim A vs claim B>` | `<pointers>` | `<preserve/provisional/resolved>` | `<lane>` |
+
+## Reuse rule
+
+No memory field, trust-state rule, merge behavior, or write-back gate should be exported without a ledger row. If evidence is not strong enough, export it as provisional and name the exact corroboration needed.

--- a/rispecs/agent-memory-provenance-framework/README.md
+++ b/rispecs/agent-memory-provenance-framework/README.md
@@ -1,0 +1,58 @@
+# Agent Memory Provenance Framework
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Control-plane scaffold for the OpenClaw model-routing study memory work. This rispec gives future waves one home for evidence and specifications about observed, inferred, and user-confirmed memory; provenance metadata; trust; scope; and write-back gates.
+
+This folder is created for `jgwill/miadi-orchestration-kit#15` and should stay aligned with `miadisabelle/workspace-openclaw#80`.
+
+## Served tracks
+
+| Track | Search | Role |
+| --- | --- | --- |
+| Academic | A2 | Establish provenance, operational memory, trust, and audit vocabulary. |
+| Technical | T3 | Turn trust vocabulary into schema, merge behavior, and write-back gates. |
+| Preflight | Scaffold readiness | Verify where memory claims and schema proposals belong before research starts. |
+
+## Inputs
+
+Future waves should read these before adding findings:
+
+1. OpenClaw model-routing study `launch-manifest.md`.
+2. OpenClaw deep-research `PROPOSAL.md`.
+3. `llms-rise-framework.txt`.
+4. Transcript or study-note excerpts for memory and user ownership claims.
+5. Repo path evidence for memory stores, instruction files, schema definitions, or write-back behavior.
+6. External provenance, RAG citation, trust, or memory-system sources after ledger intake.
+
+## What is in this folder
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Reconstruct what evidence shows about memory states, provenance fields, and confirmation boundaries. |
+| `02-intent.md` | State the desired outcome, current reality, structural tension, and non-goals for trusted memory. |
+| `03-specify.md` | Define schema, status transitions, write-back gates, review checkpoints, and consumption rules. |
+| `04-export.md` | Provide launch, resume, audit, and handoff shapes for memory-provenance work. |
+| `05-source-ledger.md` | Preserve source support for every field, trust rule, write-back rule, contradiction, and provisional claim. |
+
+## Acceptance criteria
+
+- The exact RISE wording `Reverse-engineer -> Intent-extract -> Specify -> Export` appears in the README and is used as the folder's stage language.
+- A2 and T3 share one trust vocabulary instead of diverging into theory and implementation silos.
+- Every proposed memory field is tied to a source-ledger row or marked provisional.
+- Every write-back path has a gate that distinguishes observed, inferred, and user-confirmed records.
+- Memory records preserve `source`, `observed_at`, `confidence`, `status`, `scope`, `related_task`, and `user_confirmed` before promotion.
+- The scaffold does not run Academic, Technical, Narrative, or final research.
+
+## Source-ledger rules
+
+- Evidence-backed claims need exact source pointers.
+- Repo path evidence is required before a schema or write-back behavior is called observed.
+- Transcript-only claims are provisional until corroborated.
+- Provisional schema fields must name the missing evidence needed for promotion.
+- Contradictions stay visible until resolved.
+- Human confirmation claims must identify whether the human explicitly confirmed, denied, bounded, or merely implied the memory.
+
+## Boundary
+
+This rispec does not write memory, migrate memory, alter instruction files, or decide production memory policy. It defines the control surface for future evidence and specification work.

--- a/rispecs/discord-integration-patterns/01-reverse-engineer.md
+++ b/rispecs/discord-integration-patterns/01-reverse-engineer.md
@@ -1,0 +1,31 @@
+# Reverse-Engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document reconstructs what evidence will show about discord integration patterns for the OpenClaw model-routing study. It does not define desired future behavior, durable contracts, or export commands.
+
+## Source surfaces to inspect
+
+- Study launch manifest and delegation status under `study-notes/openclaw-model-routing-85Q9htV2CBE/`.
+- Deep-research `PROPOSAL.md` sections for the served tracks listed in `README.md`.
+- `llms-rise-framework.txt` for RISE vocabulary and structural tension discipline.
+- Transcript/study notes for OpenClaw claims.
+- Repo paths or documentation relevant to this rispec's implementation claims.
+
+## Evidence reconstruction table
+
+| Claim reconstructed from evidence | Evidence surface | Evidence type | Status |
+| --- | --- | --- | --- |
+| `<claim>` | `<path/url/transcript ref>` | transcript / repo-path / docs / external-draft | provisional / corroborated / contradicted |
+
+## What to separate while reconstructing
+
+- Observed behavior vs proposed architecture.
+- Source-video claims vs independent corroboration.
+- Repo-path evidence vs product narrative.
+- Read-only research affordances vs live execution authority.
+- Current OpenClaw-specific facts vs reusable orchestration patterns.
+
+## Boundary of this stage
+
+Stop at evidence reconstruction. Do not prescribe policy, launch agents, update manifests, or smooth contradictions into a final story.

--- a/rispecs/discord-integration-patterns/02-intent.md
+++ b/rispecs/discord-integration-patterns/02-intent.md
@@ -1,0 +1,32 @@
+# Intent-Extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document turns reconstructed evidence into intent for discord integration patterns without yet defining the final execution contract.
+
+## Desired Outcome
+
+Future OpenClaw model-routing waves have a stable, evidence-led place to extract intent for this concern, so Academic and Technical work can advance without inventing incompatible vocabulary or bypassing source-ledger discipline.
+
+## Current Reality
+
+The study has identified this rispec as needed, but future agents would otherwise scatter claims across proposal notes, track findings, implementation speculation, and external drafts.
+
+## Structural Tension
+
+The research campaign needs enough structure to route evidence into reusable specifications, while avoiding premature conclusions before Academic and Technical tracks actually run.
+
+## Intent questions
+
+- What human or agent outcome does this pattern enable?
+- Which claims are durable orchestration knowledge and which are current-instance observations?
+- Which terms need Academic vocabulary before Technical implementation work can safely use them?
+- Which actions remain unauthorized by the manifest?
+- What contradictions must remain visible for reviewer resolution?
+
+## Non-goals
+
+- Do not run a research track from this file.
+- Do not authorize writes outside the selected rispec folder.
+- Do not convert provisional claims into cleared memory.
+- Do not treat external drafts as authoritative synthesis.

--- a/rispecs/discord-integration-patterns/03-specify.md
+++ b/rispecs/discord-integration-patterns/03-specify.md
@@ -1,0 +1,44 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines the reusable orchestration contract for discord integration patterns once future evidence has been reconstructed and intent has been extracted.
+
+## Contract
+
+A future wave updating this rispec must provide:
+
+1. evidence entries in `05-source-ledger.md`,
+2. reconstructed observations in `01-reverse-engineer.md`,
+3. intent statements in `02-intent.md`,
+4. specification changes here with acceptance criteria,
+5. export or handoff notes in `04-export.md`.
+
+## Required claim fields
+
+| Field | Required meaning |
+| --- | --- |
+| `claim` | Atomic statement being promoted or kept provisional. |
+| `source` | Path, URL, transcript reference, repo path, or external draft identifier. |
+| `evidence_type` | `repo-path`, `docs`, `transcript`, `external-draft`, `direct-inspection`, or `synthesis`. |
+| `confidence` | Low / medium / high plus reason. |
+| `status` | `provisional`, `corroborated`, `contradicted`, `cleared-for-synthesis`, or `rejected`. |
+| `scope` | Academic / Technical / Narrative / Final integration / reusable kit. |
+| `review_gate` | Human or agent review required before use. |
+
+## Acceptance gate
+
+A specification change is acceptable only when:
+
+- it names which future track it serves,
+- it references source-ledger evidence,
+- it preserves unauthorized-action boundaries from the launch manifest,
+- it distinguishes current-instance findings from reusable orchestration rules,
+- it adds an export/handoff consequence if later agents need to act on it.
+
+## Stop conditions
+
+- Evidence source is missing or unverifiable.
+- A live connector, runtime action, or message send would be needed but not authorized.
+- The change depends on Academic/Technical/Narrative findings that do not exist yet.
+- The claim affects memory write-back without required provenance fields.

--- a/rispecs/discord-integration-patterns/04-export.md
+++ b/rispecs/discord-integration-patterns/04-export.md
@@ -1,0 +1,37 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines how discord integration patterns findings should be exported after future authorized research waves update the rispec.
+
+## Export targets
+
+- Per-track findings in the OpenClaw model-routing study folder.
+- `model-routing-matrix.md` rows where this rispec contributes routing or runtime policy implications.
+- `delegation-status.md` updates when this rispec unblocks a track.
+- Handoff files for Academic, Technical, Narrative, or Final integration agents.
+- Future plugin-gap or runtime-inspector issues only after evidence proves the gap.
+
+## Handoff shape
+
+```markdown
+## Rispec handoff: Discord Integration Patterns
+- RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export
+- Updated files:
+- Cleared claims:
+- Provisional claims:
+- Contradictions:
+- Stop conditions still active:
+- Next authorized action:
+```
+
+## Promotion rules
+
+- Export only claims that are ledger-backed or explicitly labelled provisional.
+- Preserve contradictions in the handoff instead of hiding them.
+- Do not export memory candidates unless they include source, observed_at, confidence, status, scope, related_task, and user_confirmed.
+- Do not export launch commands that exceed the current manifest authorization.
+
+## Resume instructions
+
+A later agent should read `README.md`, `05-source-ledger.md`, and this file before continuing. If the launch manifest still authorizes only Preflight, the agent must stop before running any research track.

--- a/rispecs/discord-integration-patterns/05-source-ledger.md
+++ b/rispecs/discord-integration-patterns/05-source-ledger.md
@@ -1,0 +1,43 @@
+# Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger records claim-level provenance for discord integration patterns.
+
+## Source inventory
+
+| ID | Source | Type | Observed at | Notes |
+| --- | --- | --- | --- | --- |
+| S1 | `study-notes/openclaw-model-routing-85Q9htV2CBE/launch-manifest.md` | manifest | TBD | Track authorization and write scopes. |
+| S2 | `study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/PROPOSAL.md` | proposal | TBD | Search targets and rispec need. |
+| S3 | `/workspace/repos/jgwill/llms-txt/llms-rise-framework.txt` | framework | TBD | RISE and structural tension reference. |
+
+## Claim inventory
+
+| Claim ID | Claim | Source IDs | Evidence type | Confidence | Status | Scope | Reviewer note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C1 | `<claim>` | `S#` | transcript / repo-path / docs / external-draft | low/medium/high | provisional | Academic/Technical/etc. | `<needed review>` |
+
+## Contradiction register
+
+| Contradiction | Sources in tension | Current handling | Required resolution |
+| --- | --- | --- | --- |
+| `<tension>` | `S#` vs `S#` | keep visible | `<next evidence needed>` |
+
+## Cleared for synthesis
+
+| Claim ID | Cleared use | Cleared by | Date |
+| --- | --- | --- | --- |
+
+## Rejected or superseded claims
+
+| Claim ID | Reason | Superseding source/claim |
+| --- | --- | --- |
+
+## Ledger rules
+
+- Do not cite a claim in synthesis unless it appears here.
+- Repo path evidence is required before implementation behavior is treated as observed.
+- Transcript-only and external-draft claims remain provisional until corroborated.
+- Contradictions stay registered until a reviewer resolves them.
+- Memory candidates require source, observed_at, confidence, status, scope, related_task, and user_confirmed before write-back.

--- a/rispecs/discord-integration-patterns/README.md
+++ b/rispecs/discord-integration-patterns/README.md
@@ -1,0 +1,58 @@
+# Discord Integration Patterns
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Control-plane scaffold for studying Discord channels, threads, webhooks, bot events, and message surfaces as agent delivery and event-sourcing contexts while preserving the current read-only research posture.
+
+This folder is created for `jgwill/miadi-orchestration-kit#15` and should stay aligned with `miadisabelle/workspace-openclaw#80`.
+
+## Served tracks
+
+| Track | Search | Role |
+| --- | --- | --- |
+| Technical | T2 | Map Discord execution surfaces, event shapes, thread semantics, and webhook/bot constraints. |
+| Narrative | N1/N2/N3 later | Provide vocabulary for channel identity and messenger framing after Academic/Technical language settles. |
+| Preflight | Scaffold readiness | Keep Discord work read-only until a manifest explicitly authorizes connector behavior. |
+
+## Inputs
+
+Future waves should read these before adding findings:
+
+1. OpenClaw model-routing study `launch-manifest.md`.
+2. OpenClaw deep-research `PROPOSAL.md`, especially T2 and Narrative caveats.
+3. `llms-rise-framework.txt`.
+4. Discord documentation or repo path evidence before making implementation claims.
+5. Any existing bot/channel/thread examples must be entered in the source ledger before synthesis.
+
+## What is in this folder
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Reconstruct what source evidence actually shows before deriving intent. |
+| `02-intent.md` | State desired outcome, current reality, structural tension, non-goals, and stop conditions. |
+| `03-specify.md` | Define the reusable orchestration contract future waves must satisfy. |
+| `04-export.md` | Provide launch, resume, audit, handoff, and promotion shapes for later work. |
+| `05-source-ledger.md` | Preserve claim-level provenance, evidence type, status, contradictions, and reuse rules. |
+
+## Acceptance criteria
+
+- The exact RISE wording `Reverse-engineer -> Intent-extract -> Specify -> Export` appears in the README and is used as the folder's stage language.
+- T2 has a stable home for Discord surface evidence before any live connector work exists.
+- Channels, threads, messages, webhooks, permissions, and event replay are separate claim categories.
+- Read-only analysis is visibly separated from sending messages, creating threads, or subscribing to events.
+- Narrative terms do not override technical semantics before Technical findings exist.
+- Contradictions between Discord docs, runtime behavior, and product narrative remain visible.
+- The scaffold does not run Academic, Technical, Narrative, or final research.
+
+## Source-ledger rules
+
+- Evidence-backed claims need source surfaces and claim status.
+- Repo path evidence is required before an implementation pattern is treated as observed behavior.
+- Transcript-only claims are provisional until corroborated.
+- Provisional claims must name the missing evidence needed for promotion.
+- Contradictions stay visible until resolved; do not smooth them into consensus prose.
+- Human-facing synthesis may only use claims cleared by `05-source-ledger.md` or label them provisional.
+
+## Boundary
+
+This rispec is for research and specification of Discord patterns. It does not authorize live Discord API calls, message sends, webhook creation, or bot control.

--- a/rispecs/model-routing-orchestration/01-reverse-engineer.md
+++ b/rispecs/model-routing-orchestration/01-reverse-engineer.md
@@ -1,0 +1,64 @@
+# Reverse-engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage reconstructs what the OpenClaw model-routing study evidence actually shows about model tiers, routing decisions, cost/capability tradeoffs, fallback behavior, and review gates.
+
+It does not define the desired future policy. It prepares evidence for `02-intent.md`.
+
+## Source surfaces to inspect later
+
+| Surface | Evidence to extract | Minimum handling |
+| --- | --- | --- |
+| Study manifest | Authorized tracks, exact RISE wording, stop conditions, source-quality rules | Treat as control-plane evidence. |
+| Study proposal | A1/T1 scope, tier labels, wave expectations, rispec brief | Treat as planning evidence, not final findings. |
+| Transcript and study notes | Claims about model swapping, runtime abstraction, and routing motivation | Mark transcript-only until corroborated. |
+| OpenClaw or CLAW repo paths | Runtime dispatch, model selection, workflow stability, endpoint behavior | Require path and observed behavior. |
+| Related framework docs or code | Comparable routing patterns and terminology | Keep separate from OpenClaw-specific claims. |
+| Academic sources | Taxonomy, safety, and cost/capability terminology | Require citation details before synthesis. |
+
+## Evidence-backed observation shape
+
+Each reconstructed observation should include:
+
+- claim text,
+- source class,
+- exact source pointer,
+- whether it is evidence, provisional claim, repo path evidence, transcript-only claim, or contradiction,
+- confidence and missing corroboration,
+- candidate destination in `02-intent.md`, `03-specify.md`, or `04-export.md`.
+
+## Track-specific reconstruction questions
+
+### A1 vocabulary questions
+
+- What names do sources use for runtime abstraction, model mobility, step-aware routing, or durable workflows?
+- Which claims describe a taxonomy rather than a concrete implementation?
+- Where do cost, latency, capability, risk, and review burden appear as separate dimensions?
+- Which terms are imported from outside OpenClaw and should not be treated as transcript-native?
+
+### T1 implementation questions
+
+- What task signals are actually inspected before choosing a model tier?
+- Which tiers are observed, configured, or only proposed: `local/small`, `cheap/bulk`, `premium`, or another catalog?
+- What fallback path exists when a model is unavailable, too costly, too weak, or unsafe for the step?
+- Where does a human review gate intervene before escalation or final synthesis?
+- What data would be needed to produce a model-routing matrix row?
+
+## Boundaries
+
+- Do not turn the transcript into policy without corroboration.
+- Do not infer live routing behavior from names alone.
+- Do not collapse local, cheap, and premium tiers into quality rankings without cost and task context.
+- Do not treat model selection as purely technical if permission or review gates shape the decision.
+- Do not run Academic or Technical research from this scaffold.
+
+## Handoff shape
+
+The handoff to `02-intent.md` should contain:
+
+- evidence-supported current reality,
+- desired outcome candidates,
+- unresolved contradictions,
+- vocabulary choices with source support,
+- claims that must remain provisional.

--- a/rispecs/model-routing-orchestration/02-intent.md
+++ b/rispecs/model-routing-orchestration/02-intent.md
@@ -1,0 +1,70 @@
+# Intent-extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines the structural tension for model-routing orchestration after the evidence has been reconstructed.
+
+## Desired outcome
+
+Future OpenClaw research and build waves can express model routing as a durable orchestration pattern: task steps expose routing signals, the runtime selects an appropriate model tier, fallback and review gates are visible, and model-routing matrix outputs remain traceable to evidence.
+
+## Current reality
+
+The study begins from a tension between:
+
+- agents described as locked to one model,
+- runtime-abstraction claims that imply model mobility,
+- cost/capability tradeoffs that may vary by task step,
+- safety and review needs that can override cheapest-route logic,
+- multiple tracks that could invent incompatible routing vocabulary.
+
+Without this rispec, later waves may mix taxonomy, implementation details, and policy conclusions in the same document.
+
+## Structural tension
+
+| Current reality | Desired outcome | Advancing move |
+| --- | --- | --- |
+| Model-routing language may come from transcript, proposal, papers, and code with different meanings. | One vocabulary is shared by A1 and T1, with provenance attached. | Reconstruct terminology first, then promote only supported terms into specification. |
+| Routing can be framed as cost saving only. | Routing balances cost, capability, latency, reliability, permission scope, and review needs. | Require each routing rule to name the dimension it optimizes and the evidence for that choice. |
+| A model swap can break agent behavior if workflow logic depends on provider assumptions. | Workflow logic remains stable while model choice changes at runtime. | Separate task contract, model catalog, fallback, and review gate in the specification. |
+| Fallback and escalation can be hidden in implementation details. | Fallback and escalation are inspectable matrix columns. | Make matrix outputs part of the handoff contract. |
+
+## Creative advancement scenarios
+
+### Scenario: classify lightweight work
+
+**Desired Outcome:** A future dispatcher can route simple classification or triage to a low-cost tier while preserving auditability.
+
+**Current Reality:** The study proposes tiers, but future evidence must show which tasks actually fit each tier.
+
+**Natural Progression:** Reverse-engineered task examples become candidate matrix rows; each row records task signals, chosen tier, fallback path, and review requirement.
+
+**Resolution:** A low-risk route is documented without implying that all classification is safe or cheap by default.
+
+### Scenario: escalate hard judgment
+
+**Desired Outcome:** Hard judgment, trust evaluation, or final synthesis can move to a premium tier with visible reason and review context.
+
+**Current Reality:** Premium model use can be justified by habit unless the route records what made the step hard.
+
+**Natural Progression:** The specification requires escalation triggers and a reviewer-visible explanation before premium use is treated as policy.
+
+**Resolution:** Premium routing becomes a controlled decision, not an unexamined default.
+
+## Non-goals
+
+- Do not choose production models.
+- Do not set budget policy.
+- Do not run routing experiments.
+- Do not make final Academic or Technical findings.
+- Do not authorize live OpenClaw connector work.
+
+## Handoff shape
+
+The handoff to `03-specify.md` should provide:
+
+- approved vocabulary,
+- structural tension table,
+- routing dimensions to include,
+- non-goals,
+- claims that need source-ledger status before use.

--- a/rispecs/model-routing-orchestration/03-specify.md
+++ b/rispecs/model-routing-orchestration/03-specify.md
@@ -1,0 +1,77 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines the control-plane contract for future model-routing research or implementation waves.
+
+## Required reading order
+
+1. This README.
+2. `05-source-ledger.md`.
+3. `01-reverse-engineer.md`.
+4. `02-intent.md`.
+5. Active track findings only if the study manifest authorizes the track.
+6. Source evidence named by the active ledger rows.
+
+## Routing decision contract
+
+Every proposed routing rule must declare:
+
+| Field | Requirement |
+| --- | --- |
+| Task class | What the agent step is trying to produce. |
+| Task signals | Observable inputs used to decide the route. |
+| Candidate tier | Example tier such as `local/small`, `cheap/bulk`, or `premium`, if evidence supports that label. |
+| Capability reason | Why that tier can handle the step. |
+| Cost or latency reason | Whether cost or speed matters for the step. |
+| Safety reason | Whether permission scope, data sensitivity, or review risk changes the route. |
+| Fallback path | What happens when the selected tier fails or is unavailable. |
+| Review gate | Whether a human or reviewer lane must inspect before escalation or final output. |
+| Evidence status | Evidence, provisional claim, repo path evidence, transcript-only claim, or contradiction. |
+
+## Model-routing matrix output
+
+Future waves should produce rows shaped like:
+
+| Step | Signals | Preferred tier | Fallback | Review gate | Evidence pointer | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `<task step>` | `<observed signals>` | `<tier>` | `<fallback>` | `<gate>` | `<ledger id>` | `<status>` |
+
+Rows without a ledger pointer stay provisional.
+
+## Lane contract
+
+| Lane | Owns | Exit artefact |
+| --- | --- | --- |
+| A1 taxonomy lane | Terms, external concepts, academic framing | Vocabulary map with source status. |
+| T1 implementation lane | Dispatch behavior, path evidence, pseudo-interface shape | Routing matrix rows and implementation notes. |
+| Review lane | Contradictions, unsupported tier choices, overbroad claims | Revision list with required evidence. |
+| Ledger lane | Claim status and source support | Updated `05-source-ledger.md`. |
+
+## Review gates
+
+Require review before a routing rule is promoted when:
+
+- a task moves from low-cost to premium tier,
+- a task crosses from read-only analysis into write or execute authority,
+- the route handles sensitive memory or user data,
+- the fallback changes output quality or trust level,
+- the evidence is transcript-only or inferred from naming.
+
+## Stop conditions
+
+- The active track is not authorized by the launch manifest.
+- A routing conclusion lacks ledger status.
+- A repo implementation claim has no path-level evidence.
+- A contradiction is discovered but not recorded.
+- A proposed export would write outside the authorized study or rispec scope.
+
+## Handoff shape
+
+The handoff to `04-export.md` should include:
+
+- the matrix rows ready for reuse,
+- unresolved matrix rows that must remain provisional,
+- review decisions,
+- exact evidence pointers,
+- next authorized launch or audit prompt shape.

--- a/rispecs/model-routing-orchestration/04-export.md
+++ b/rispecs/model-routing-orchestration/04-export.md
@@ -1,0 +1,68 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This stage defines how model-routing orchestration knowledge is launched, resumed, audited, and handed off after the study manifest authorizes a track.
+
+## Launch prompt shape
+
+Use this only after the active manifest authorizes A1 or T1:
+
+```text
+Read the OpenClaw model-routing study launch manifest, this rispec folder, and the current source ledger first.
+
+Operate only on the authorized track.
+Use the RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export.
+
+Goal:
+- For A1, produce vocabulary and taxonomy findings for model routing.
+- For T1, produce routing matrix rows, fallback expectations, and review gates.
+
+Required handoff:
+- exact sources read,
+- claim status for every routing rule,
+- model-routing matrix rows,
+- contradictions,
+- unsupported claims that remain provisional,
+- next safe resume instruction.
+```
+
+## Resume pattern
+
+On resume:
+
+1. Read the launch manifest and confirm the authorized track.
+2. Read `05-source-ledger.md` before any synthesis.
+3. Read the last track findings or handoff file.
+4. Continue only the next incomplete lane.
+5. Preserve prior contradictions unless resolved with evidence.
+
+## Audit pattern
+
+An audit pass should verify:
+
+- the exact RISE wording is preserved,
+- every matrix row has a ledger pointer,
+- implementation claims have repo path evidence,
+- transcript-only claims remain provisional,
+- cost and capability claims are not merged without support,
+- fallback and review gates are explicit,
+- no Academic, Technical, Narrative, or final research was run during scaffold work.
+
+## Export destinations
+
+| Destination | Allowed content | Required status |
+| --- | --- | --- |
+| A1 findings | Taxonomy, vocabulary, academic source map | Ledger-backed or clearly provisional. |
+| T1 findings | Routing matrix, dispatch contract, fallback and review gates | Ledger-backed with repo path evidence for implementation behavior. |
+| Other rispecs | Permission, memory, runtime, or Discord constraints that affect routing | Cross-linked and source-ledgered. |
+| Study handoff | Next command, blockers, evidence gaps | No final synthesis unless authorized. |
+
+## Handoff checklist
+
+- Source ledger updated.
+- Matrix rows status-tagged.
+- Contradictions preserved.
+- Claims separated by source type.
+- Review asks written as concrete evidence gaps.
+- Next track entry point names the manifest authorization requirement.

--- a/rispecs/model-routing-orchestration/05-source-ledger.md
+++ b/rispecs/model-routing-orchestration/05-source-ledger.md
@@ -1,0 +1,56 @@
+# Model Routing Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger preserves provenance for model-routing orchestration claims in the OpenClaw model-routing study.
+
+## Related issues
+
+- `miadisabelle/workspace-openclaw#80`
+- `jgwill/miadi-orchestration-kit#15`
+
+## Ledger rules
+
+| Status | Meaning | Promotion rule |
+| --- | --- | --- |
+| Evidence | Directly supported by a cited source surface. | Can be used if the source pointer is specific. |
+| Repo path evidence | Supported by code, config, docs, or test paths in a repo. | Required for implementation behavior claims. |
+| Transcript-only claim | Present in transcript or video notes only. | Keep provisional until corroborated. |
+| Provisional claim | Plausible but missing sufficient support. | Name missing evidence before reuse. |
+| Contradiction | Sources conflict or imply incompatible rules. | Preserve until a review lane resolves it. |
+
+## Source classes
+
+| Source class | Examples | Use |
+| --- | --- | --- |
+| Study control | `launch-manifest.md`, `PROPOSAL.md` | Scope, tracks, file expectations, guardrails. |
+| Transcript and notes | source video transcript, timestamped notes | Motivation and candidate claims. |
+| Repo path evidence | OpenClaw, CLAW, gaia-endpoint, LangGraph paths | Observed implementation behavior. |
+| External sources | papers, docs, framework references | Vocabulary and comparable patterns. |
+| Human confirmation | explicit operator decision or review note | Permission to promote or bound a claim. |
+
+## Seed entries
+
+| ID | Claim | Status | Evidence pointer | Notes |
+| --- | --- | --- | --- | --- |
+| MR-001 | This rispec serves A1 and T1 for the OpenClaw model-routing study. | Evidence | Study proposal section "Rispec Scaffold Index"; issue `jgwill/miadi-orchestration-kit#15` context. | Control-plane scope only. |
+| MR-002 | Required RISE wording is `Reverse-engineer -> Intent-extract -> Specify -> Export`. | Evidence | Study launch manifest "RISE Wording (Required Exactly)". | Must remain exact. |
+| MR-003 | Proposed model tiers include `local/small`, `cheap/bulk`, and `premium`. | Provisional claim | Study proposal context summary and model-routing rispec brief. | Needs corroboration before becoming routing policy. |
+| MR-004 | Implementation claims about dispatch or runtime model selection require repo path evidence. | Evidence | Study launch manifest source-quality rules. | Applies to T1. |
+| MR-005 | Transcript-only routing claims are provisional until corroborated. | Evidence | Study launch manifest required source quality. | Applies to A1 and T1. |
+
+## Claim intake table
+
+| ID | Claim | Source class | Exact pointer | Status | Confidence | Related track | Missing evidence | Resolution notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<id>` | `<claim>` | `<class>` | `<path/url/time>` | `<status>` | `<low/medium/high>` | `<A1/T1>` | `<needed support>` | `<review result>` |
+
+## Contradiction log
+
+| ID | Conflicting claims | Sources | Current handling | Review owner |
+| --- | --- | --- | --- | --- |
+| `<id>` | `<claim A vs claim B>` | `<pointers>` | `<preserve/provisional/resolved>` | `<lane>` |
+
+## Reuse rule
+
+No routing rule, tier recommendation, fallback path, or review-gate claim should be exported without a ledger row. If evidence is not strong enough, export the row as provisional and name the exact corroboration needed.

--- a/rispecs/model-routing-orchestration/README.md
+++ b/rispecs/model-routing-orchestration/README.md
@@ -1,0 +1,58 @@
+# Model Routing Orchestration
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Control-plane scaffold for the OpenClaw model-routing study. This rispec gives future Academic and Technical waves one place to put evidence, intent, specifications, and export notes about model tiers, routing policy, fallback behavior, review gates, and model-routing matrix outputs.
+
+This folder is created for `jgwill/miadi-orchestration-kit#15` and should stay aligned with `miadisabelle/workspace-openclaw#80`.
+
+## Served tracks
+
+| Track | Search | Role |
+| --- | --- | --- |
+| Academic | A1 | Establish vocabulary for runtime abstraction, model mobility, and cost/capability tradeoffs. |
+| Technical | T1 | Turn the vocabulary into step-aware routing contracts, dispatch traces, fallback gates, and matrix outputs. |
+| Preflight | Scaffold readiness | Verify that later research waves know where claims and evidence belong before any track runs. |
+
+## Inputs
+
+Future waves should read these before adding findings:
+
+1. OpenClaw model-routing study `launch-manifest.md`.
+2. OpenClaw deep-research `PROPOSAL.md`.
+3. `llms-rise-framework.txt`.
+4. Transcript or study-note excerpts for model-routing claims.
+5. Repo path evidence for any OpenClaw, CLAW, gaia-endpoint, LangGraph, or dispatch implementation claim.
+6. Prior track findings only after they have source-ledger entries.
+
+## What is in this folder
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Reconstruct what evidence shows about model routing without defining final policy. |
+| `02-intent.md` | State the desired outcome, current reality, structural tension, and boundaries for routed execution. |
+| `03-specify.md` | Define the orchestration contract for task signals, tier selection, fallback, review, and matrix outputs. |
+| `04-export.md` | Provide launch, resume, audit, and handoff shapes for future model-routing waves. |
+| `05-source-ledger.md` | Preserve claim-level provenance, evidence type, status, contradictions, and reuse rules. |
+
+## Acceptance criteria
+
+- The exact RISE wording `Reverse-engineer -> Intent-extract -> Specify -> Export` appears in the README and is used as the folder's stage language.
+- A1 and T1 can both write here without creating separate vocabularies for the same routing pattern.
+- Every routing rule distinguishes task signal, model tier, fallback condition, review gate, and expected matrix output.
+- Cost/capability tradeoffs are treated as evidence-backed claims, not assumptions.
+- Any model-routing matrix row can be traced to source-ledger evidence or marked provisional.
+- The scaffold does not run Academic, Technical, Narrative, or final research.
+
+## Source-ledger rules
+
+- Evidence-backed claims need source surfaces and claim status.
+- Repo path evidence is required before an implementation pattern is treated as observed behavior.
+- Transcript-only claims are provisional until corroborated.
+- Provisional claims must name the missing evidence needed for promotion.
+- Contradictions stay visible until resolved; do not smooth them into consensus prose.
+- Cost, latency, capability, safety, and review-gate claims must be tracked separately when their evidence differs.
+
+## Boundary
+
+This rispec controls the model-routing study surface. It does not select live models, run routing simulations, authorize connector work, or decide production routing policy.

--- a/rispecs/openclaw-runtime-patterns/01-reverse-engineer.md
+++ b/rispecs/openclaw-runtime-patterns/01-reverse-engineer.md
@@ -1,0 +1,31 @@
+# Reverse-Engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document reconstructs what evidence will show about openclaw runtime patterns for the OpenClaw model-routing study. It does not define desired future behavior, durable contracts, or export commands.
+
+## Source surfaces to inspect
+
+- Study launch manifest and delegation status under `study-notes/openclaw-model-routing-85Q9htV2CBE/`.
+- Deep-research `PROPOSAL.md` sections for the served tracks listed in `README.md`.
+- `llms-rise-framework.txt` for RISE vocabulary and structural tension discipline.
+- Transcript/study notes for OpenClaw claims.
+- Repo paths or documentation relevant to this rispec's implementation claims.
+
+## Evidence reconstruction table
+
+| Claim reconstructed from evidence | Evidence surface | Evidence type | Status |
+| --- | --- | --- | --- |
+| `<claim>` | `<path/url/transcript ref>` | transcript / repo-path / docs / external-draft | provisional / corroborated / contradicted |
+
+## What to separate while reconstructing
+
+- Observed behavior vs proposed architecture.
+- Source-video claims vs independent corroboration.
+- Repo-path evidence vs product narrative.
+- Read-only research affordances vs live execution authority.
+- Current OpenClaw-specific facts vs reusable orchestration patterns.
+
+## Boundary of this stage
+
+Stop at evidence reconstruction. Do not prescribe policy, launch agents, update manifests, or smooth contradictions into a final story.

--- a/rispecs/openclaw-runtime-patterns/02-intent.md
+++ b/rispecs/openclaw-runtime-patterns/02-intent.md
@@ -1,0 +1,32 @@
+# Intent-Extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document turns reconstructed evidence into intent for openclaw runtime patterns without yet defining the final execution contract.
+
+## Desired Outcome
+
+Future OpenClaw model-routing waves have a stable, evidence-led place to extract intent for this concern, so Academic and Technical work can advance without inventing incompatible vocabulary or bypassing source-ledger discipline.
+
+## Current Reality
+
+The study has identified this rispec as needed, but future agents would otherwise scatter claims across proposal notes, track findings, implementation speculation, and external drafts.
+
+## Structural Tension
+
+The research campaign needs enough structure to route evidence into reusable specifications, while avoiding premature conclusions before Academic and Technical tracks actually run.
+
+## Intent questions
+
+- What human or agent outcome does this pattern enable?
+- Which claims are durable orchestration knowledge and which are current-instance observations?
+- Which terms need Academic vocabulary before Technical implementation work can safely use them?
+- Which actions remain unauthorized by the manifest?
+- What contradictions must remain visible for reviewer resolution?
+
+## Non-goals
+
+- Do not run a research track from this file.
+- Do not authorize writes outside the selected rispec folder.
+- Do not convert provisional claims into cleared memory.
+- Do not treat external drafts as authoritative synthesis.

--- a/rispecs/openclaw-runtime-patterns/03-specify.md
+++ b/rispecs/openclaw-runtime-patterns/03-specify.md
@@ -1,0 +1,44 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines the reusable orchestration contract for openclaw runtime patterns once future evidence has been reconstructed and intent has been extracted.
+
+## Contract
+
+A future wave updating this rispec must provide:
+
+1. evidence entries in `05-source-ledger.md`,
+2. reconstructed observations in `01-reverse-engineer.md`,
+3. intent statements in `02-intent.md`,
+4. specification changes here with acceptance criteria,
+5. export or handoff notes in `04-export.md`.
+
+## Required claim fields
+
+| Field | Required meaning |
+| --- | --- |
+| `claim` | Atomic statement being promoted or kept provisional. |
+| `source` | Path, URL, transcript reference, repo path, or external draft identifier. |
+| `evidence_type` | `repo-path`, `docs`, `transcript`, `external-draft`, `direct-inspection`, or `synthesis`. |
+| `confidence` | Low / medium / high plus reason. |
+| `status` | `provisional`, `corroborated`, `contradicted`, `cleared-for-synthesis`, or `rejected`. |
+| `scope` | Academic / Technical / Narrative / Final integration / reusable kit. |
+| `review_gate` | Human or agent review required before use. |
+
+## Acceptance gate
+
+A specification change is acceptable only when:
+
+- it names which future track it serves,
+- it references source-ledger evidence,
+- it preserves unauthorized-action boundaries from the launch manifest,
+- it distinguishes current-instance findings from reusable orchestration rules,
+- it adds an export/handoff consequence if later agents need to act on it.
+
+## Stop conditions
+
+- Evidence source is missing or unverifiable.
+- A live connector, runtime action, or message send would be needed but not authorized.
+- The change depends on Academic/Technical/Narrative findings that do not exist yet.
+- The claim affects memory write-back without required provenance fields.

--- a/rispecs/openclaw-runtime-patterns/04-export.md
+++ b/rispecs/openclaw-runtime-patterns/04-export.md
@@ -1,0 +1,37 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines how openclaw runtime patterns findings should be exported after future authorized research waves update the rispec.
+
+## Export targets
+
+- Per-track findings in the OpenClaw model-routing study folder.
+- `model-routing-matrix.md` rows where this rispec contributes routing or runtime policy implications.
+- `delegation-status.md` updates when this rispec unblocks a track.
+- Handoff files for Academic, Technical, Narrative, or Final integration agents.
+- Future plugin-gap or runtime-inspector issues only after evidence proves the gap.
+
+## Handoff shape
+
+```markdown
+## Rispec handoff: OpenClaw Runtime Patterns
+- RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export
+- Updated files:
+- Cleared claims:
+- Provisional claims:
+- Contradictions:
+- Stop conditions still active:
+- Next authorized action:
+```
+
+## Promotion rules
+
+- Export only claims that are ledger-backed or explicitly labelled provisional.
+- Preserve contradictions in the handoff instead of hiding them.
+- Do not export memory candidates unless they include source, observed_at, confidence, status, scope, related_task, and user_confirmed.
+- Do not export launch commands that exceed the current manifest authorization.
+
+## Resume instructions
+
+A later agent should read `README.md`, `05-source-ledger.md`, and this file before continuing. If the launch manifest still authorizes only Preflight, the agent must stop before running any research track.

--- a/rispecs/openclaw-runtime-patterns/05-source-ledger.md
+++ b/rispecs/openclaw-runtime-patterns/05-source-ledger.md
@@ -1,0 +1,43 @@
+# Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger records claim-level provenance for openclaw runtime patterns.
+
+## Source inventory
+
+| ID | Source | Type | Observed at | Notes |
+| --- | --- | --- | --- | --- |
+| S1 | `study-notes/openclaw-model-routing-85Q9htV2CBE/launch-manifest.md` | manifest | TBD | Track authorization and write scopes. |
+| S2 | `study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/PROPOSAL.md` | proposal | TBD | Search targets and rispec need. |
+| S3 | `/workspace/repos/jgwill/llms-txt/llms-rise-framework.txt` | framework | TBD | RISE and structural tension reference. |
+
+## Claim inventory
+
+| Claim ID | Claim | Source IDs | Evidence type | Confidence | Status | Scope | Reviewer note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C1 | `<claim>` | `S#` | transcript / repo-path / docs / external-draft | low/medium/high | provisional | Academic/Technical/etc. | `<needed review>` |
+
+## Contradiction register
+
+| Contradiction | Sources in tension | Current handling | Required resolution |
+| --- | --- | --- | --- |
+| `<tension>` | `S#` vs `S#` | keep visible | `<next evidence needed>` |
+
+## Cleared for synthesis
+
+| Claim ID | Cleared use | Cleared by | Date |
+| --- | --- | --- | --- |
+
+## Rejected or superseded claims
+
+| Claim ID | Reason | Superseding source/claim |
+| --- | --- | --- |
+
+## Ledger rules
+
+- Do not cite a claim in synthesis unless it appears here.
+- Repo path evidence is required before implementation behavior is treated as observed.
+- Transcript-only and external-draft claims remain provisional until corroborated.
+- Contradictions stay registered until a reviewer resolves them.
+- Memory candidates require source, observed_at, confidence, status, scope, related_task, and user_confirmed before write-back.

--- a/rispecs/openclaw-runtime-patterns/README.md
+++ b/rispecs/openclaw-runtime-patterns/README.md
@@ -1,0 +1,58 @@
+# OpenClaw Runtime Patterns
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Control-plane scaffold for reconstructing OpenClaw runtime abstraction, durable workflow behavior, CLAW/gaia-endpoint topology, model-swap survival, session isolation, and runtime-inspector evidence.
+
+This folder is created for `jgwill/miadi-orchestration-kit#15` and should stay aligned with `miadisabelle/workspace-openclaw#80`.
+
+## Served tracks
+
+| Track | Search | Role |
+| --- | --- | --- |
+| Academic | A1 | Anchor runtime abstraction vocabulary and durable workflow claims. |
+| Technical | T4 | Map concrete runtime/session/endpoint patterns with path-level evidence. |
+| Technical | T1/T3 | Connect runtime choices to model routing and memory provenance without collapsing boundaries. |
+
+## Inputs
+
+Future waves should read these before adding findings:
+
+1. OpenClaw model-routing study `launch-manifest.md`.
+2. OpenClaw deep-research `PROPOSAL.md`, especially runtime abstraction and T4.
+3. `llms-rise-framework.txt`.
+4. OpenClaw/CLAW/gaia-endpoint repo path evidence before implementation claims.
+5. Kherix or other external drafts only after ledger entry as provisional external research.
+
+## What is in this folder
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Reconstruct what source evidence actually shows before deriving intent. |
+| `02-intent.md` | State desired outcome, current reality, structural tension, non-goals, and stop conditions. |
+| `03-specify.md` | Define the reusable orchestration contract future waves must satisfy. |
+| `04-export.md` | Provide launch, resume, audit, handoff, and promotion shapes for later work. |
+| `05-source-ledger.md` | Preserve claim-level provenance, evidence type, status, contradictions, and reuse rules. |
+
+## Acceptance criteria
+
+- The exact RISE wording `Reverse-engineer -> Intent-extract -> Specify -> Export` appears in the README and is used as the folder's stage language.
+- A1 and T4 can share runtime vocabulary while preserving evidence type and confidence.
+- Every runtime claim names whether it comes from transcript, study note, repo path, external draft, or direct inspection.
+- Session isolation, endpoint maps, model-swap behavior, and workflow durability are tracked separately.
+- Runtime-inspector needs are specified as read-only unless the manifest changes.
+- No production runtime behavior is asserted without path-level or independently corroborated evidence.
+- The scaffold does not run Academic, Technical, Narrative, or final research.
+
+## Source-ledger rules
+
+- Evidence-backed claims need source surfaces and claim status.
+- Repo path evidence is required before an implementation pattern is treated as observed behavior.
+- Transcript-only claims are provisional until corroborated.
+- Provisional claims must name the missing evidence needed for promotion.
+- Contradictions stay visible until resolved; do not smooth them into consensus prose.
+- Human-facing synthesis may only use claims cleared by `05-source-ledger.md` or label them provisional.
+
+## Boundary
+
+This rispec prepares future runtime research. It does not inspect live runtime state, run OpenClaw, operate gaia-endpoint, or implement the runtime inspector.

--- a/rispecs/permission-scoping-orchestration/01-reverse-engineer.md
+++ b/rispecs/permission-scoping-orchestration/01-reverse-engineer.md
@@ -1,0 +1,31 @@
+# Reverse-Engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document reconstructs what evidence will show about permission scoping orchestration for the OpenClaw model-routing study. It does not define desired future behavior, durable contracts, or export commands.
+
+## Source surfaces to inspect
+
+- Study launch manifest and delegation status under `study-notes/openclaw-model-routing-85Q9htV2CBE/`.
+- Deep-research `PROPOSAL.md` sections for the served tracks listed in `README.md`.
+- `llms-rise-framework.txt` for RISE vocabulary and structural tension discipline.
+- Transcript/study notes for OpenClaw claims.
+- Repo paths or documentation relevant to this rispec's implementation claims.
+
+## Evidence reconstruction table
+
+| Claim reconstructed from evidence | Evidence surface | Evidence type | Status |
+| --- | --- | --- | --- |
+| `<claim>` | `<path/url/transcript ref>` | transcript / repo-path / docs / external-draft | provisional / corroborated / contradicted |
+
+## What to separate while reconstructing
+
+- Observed behavior vs proposed architecture.
+- Source-video claims vs independent corroboration.
+- Repo-path evidence vs product narrative.
+- Read-only research affordances vs live execution authority.
+- Current OpenClaw-specific facts vs reusable orchestration patterns.
+
+## Boundary of this stage
+
+Stop at evidence reconstruction. Do not prescribe policy, launch agents, update manifests, or smooth contradictions into a final story.

--- a/rispecs/permission-scoping-orchestration/02-intent.md
+++ b/rispecs/permission-scoping-orchestration/02-intent.md
@@ -1,0 +1,32 @@
+# Intent-Extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document turns reconstructed evidence into intent for permission scoping orchestration without yet defining the final execution contract.
+
+## Desired Outcome
+
+Future OpenClaw model-routing waves have a stable, evidence-led place to extract intent for this concern, so Academic and Technical work can advance without inventing incompatible vocabulary or bypassing source-ledger discipline.
+
+## Current Reality
+
+The study has identified this rispec as needed, but future agents would otherwise scatter claims across proposal notes, track findings, implementation speculation, and external drafts.
+
+## Structural Tension
+
+The research campaign needs enough structure to route evidence into reusable specifications, while avoiding premature conclusions before Academic and Technical tracks actually run.
+
+## Intent questions
+
+- What human or agent outcome does this pattern enable?
+- Which claims are durable orchestration knowledge and which are current-instance observations?
+- Which terms need Academic vocabulary before Technical implementation work can safely use them?
+- Which actions remain unauthorized by the manifest?
+- What contradictions must remain visible for reviewer resolution?
+
+## Non-goals
+
+- Do not run a research track from this file.
+- Do not authorize writes outside the selected rispec folder.
+- Do not convert provisional claims into cleared memory.
+- Do not treat external drafts as authoritative synthesis.

--- a/rispecs/permission-scoping-orchestration/03-specify.md
+++ b/rispecs/permission-scoping-orchestration/03-specify.md
@@ -1,0 +1,44 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines the reusable orchestration contract for permission scoping orchestration once future evidence has been reconstructed and intent has been extracted.
+
+## Contract
+
+A future wave updating this rispec must provide:
+
+1. evidence entries in `05-source-ledger.md`,
+2. reconstructed observations in `01-reverse-engineer.md`,
+3. intent statements in `02-intent.md`,
+4. specification changes here with acceptance criteria,
+5. export or handoff notes in `04-export.md`.
+
+## Required claim fields
+
+| Field | Required meaning |
+| --- | --- |
+| `claim` | Atomic statement being promoted or kept provisional. |
+| `source` | Path, URL, transcript reference, repo path, or external draft identifier. |
+| `evidence_type` | `repo-path`, `docs`, `transcript`, `external-draft`, `direct-inspection`, or `synthesis`. |
+| `confidence` | Low / medium / high plus reason. |
+| `status` | `provisional`, `corroborated`, `contradicted`, `cleared-for-synthesis`, or `rejected`. |
+| `scope` | Academic / Technical / Narrative / Final integration / reusable kit. |
+| `review_gate` | Human or agent review required before use. |
+
+## Acceptance gate
+
+A specification change is acceptable only when:
+
+- it names which future track it serves,
+- it references source-ledger evidence,
+- it preserves unauthorized-action boundaries from the launch manifest,
+- it distinguishes current-instance findings from reusable orchestration rules,
+- it adds an export/handoff consequence if later agents need to act on it.
+
+## Stop conditions
+
+- Evidence source is missing or unverifiable.
+- A live connector, runtime action, or message send would be needed but not authorized.
+- The change depends on Academic/Technical/Narrative findings that do not exist yet.
+- The claim affects memory write-back without required provenance fields.

--- a/rispecs/permission-scoping-orchestration/04-export.md
+++ b/rispecs/permission-scoping-orchestration/04-export.md
@@ -1,0 +1,37 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines how permission scoping orchestration findings should be exported after future authorized research waves update the rispec.
+
+## Export targets
+
+- Per-track findings in the OpenClaw model-routing study folder.
+- `model-routing-matrix.md` rows where this rispec contributes routing or runtime policy implications.
+- `delegation-status.md` updates when this rispec unblocks a track.
+- Handoff files for Academic, Technical, Narrative, or Final integration agents.
+- Future plugin-gap or runtime-inspector issues only after evidence proves the gap.
+
+## Handoff shape
+
+```markdown
+## Rispec handoff: Permission Scoping Orchestration
+- RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export
+- Updated files:
+- Cleared claims:
+- Provisional claims:
+- Contradictions:
+- Stop conditions still active:
+- Next authorized action:
+```
+
+## Promotion rules
+
+- Export only claims that are ledger-backed or explicitly labelled provisional.
+- Preserve contradictions in the handoff instead of hiding them.
+- Do not export memory candidates unless they include source, observed_at, confidence, status, scope, related_task, and user_confirmed.
+- Do not export launch commands that exceed the current manifest authorization.
+
+## Resume instructions
+
+A later agent should read `README.md`, `05-source-ledger.md`, and this file before continuing. If the launch manifest still authorizes only Preflight, the agent must stop before running any research track.

--- a/rispecs/permission-scoping-orchestration/05-source-ledger.md
+++ b/rispecs/permission-scoping-orchestration/05-source-ledger.md
@@ -1,0 +1,43 @@
+# Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger records claim-level provenance for permission scoping orchestration.
+
+## Source inventory
+
+| ID | Source | Type | Observed at | Notes |
+| --- | --- | --- | --- | --- |
+| S1 | `study-notes/openclaw-model-routing-85Q9htV2CBE/launch-manifest.md` | manifest | TBD | Track authorization and write scopes. |
+| S2 | `study-notes/openclaw-model-routing-85Q9htV2CBE/preparing-deep-research/PROPOSAL.md` | proposal | TBD | Search targets and rispec need. |
+| S3 | `/workspace/repos/jgwill/llms-txt/llms-rise-framework.txt` | framework | TBD | RISE and structural tension reference. |
+
+## Claim inventory
+
+| Claim ID | Claim | Source IDs | Evidence type | Confidence | Status | Scope | Reviewer note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C1 | `<claim>` | `S#` | transcript / repo-path / docs / external-draft | low/medium/high | provisional | Academic/Technical/etc. | `<needed review>` |
+
+## Contradiction register
+
+| Contradiction | Sources in tension | Current handling | Required resolution |
+| --- | --- | --- | --- |
+| `<tension>` | `S#` vs `S#` | keep visible | `<next evidence needed>` |
+
+## Cleared for synthesis
+
+| Claim ID | Cleared use | Cleared by | Date |
+| --- | --- | --- | --- |
+
+## Rejected or superseded claims
+
+| Claim ID | Reason | Superseding source/claim |
+| --- | --- | --- |
+
+## Ledger rules
+
+- Do not cite a claim in synthesis unless it appears here.
+- Repo path evidence is required before implementation behavior is treated as observed.
+- Transcript-only and external-draft claims remain provisional until corroborated.
+- Contradictions stay registered until a reviewer resolves them.
+- Memory candidates require source, observed_at, confidence, status, scope, related_task, and user_confirmed before write-back.

--- a/rispecs/permission-scoping-orchestration/README.md
+++ b/rispecs/permission-scoping-orchestration/README.md
@@ -1,0 +1,58 @@
+# Permission Scoping Orchestration
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Control-plane scaffold for researching and specifying principle-of-least-authority boundaries, capability amplification checkpoints, human review gates, and read/write/execute stop conditions for OpenClaw-style agent runtimes.
+
+This folder is created for `jgwill/miadi-orchestration-kit#15` and should stay aligned with `miadisabelle/workspace-openclaw#80`.
+
+## Served tracks
+
+| Track | Search | Role |
+| --- | --- | --- |
+| Academic | A3 | Ground permission scoping, capability amplification, and human review vocabulary. |
+| Technical | T1/T4 | Map permission gates to routing policy, runtime inspection, execution surfaces, and stop conditions. |
+| Preflight | Scaffold readiness | Confirm future waves know how to separate read-only research from write/execute authority. |
+
+## Inputs
+
+Future waves should read these before adding findings:
+
+1. OpenClaw model-routing study `launch-manifest.md`.
+2. OpenClaw deep-research `PROPOSAL.md`, especially A3 and technical track constraints.
+3. `llms-rise-framework.txt`.
+4. Any transcript/study-note claims about permissions, review points, or capability escalation.
+5. Repo path evidence before asserting runtime behavior, connector authority, or live execution capability.
+
+## What is in this folder
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Reconstruct what source evidence actually shows before deriving intent. |
+| `02-intent.md` | State desired outcome, current reality, structural tension, non-goals, and stop conditions. |
+| `03-specify.md` | Define the reusable orchestration contract future waves must satisfy. |
+| `04-export.md` | Provide launch, resume, audit, handoff, and promotion shapes for later work. |
+| `05-source-ledger.md` | Preserve claim-level provenance, evidence type, status, contradictions, and reuse rules. |
+
+## Acceptance criteria
+
+- The exact RISE wording `Reverse-engineer -> Intent-extract -> Specify -> Export` appears in the README and is used as the folder's stage language.
+- A3 can write literature-style permission findings here without mixing them with implementation conclusions.
+- Technical waves can represent read-only, write, execute, network, connector, and memory authority as separate scopes.
+- Every capability amplification claim names its trigger, reviewer, allowed action, denied action, and rollback/stop condition.
+- No live Discord/OpenClaw connector work is implied by this scaffold.
+- All permission rules are ledger-backed or explicitly provisional.
+- The scaffold does not run Academic, Technical, Narrative, or final research.
+
+## Source-ledger rules
+
+- Evidence-backed claims need source surfaces and claim status.
+- Repo path evidence is required before an implementation pattern is treated as observed behavior.
+- Transcript-only claims are provisional until corroborated.
+- Provisional claims must name the missing evidence needed for promotion.
+- Contradictions stay visible until resolved; do not smooth them into consensus prose.
+- Human-facing synthesis may only use claims cleared by `05-source-ledger.md` or label them provisional.
+
+## Boundary
+
+This rispec defines orchestration boundaries for future research. It does not grant permissions, run connectors, modify runtime policies, or approve live execution.


### PR DESCRIPTION
## Summary
- scaffolds five OpenClaw model-routing rispec folders under `rispecs/`
- adds the required RISE files in each folder: README, reverse-engineer, intent, specify, export, source ledger
- seeds served tracks, inputs, acceptance criteria, source-ledger rules, boundaries, and handoff/export shapes

## Verification
- verified all five folders contain the required six files
- verified each README includes the exact RISE wording: `Reverse-engineer -> Intent-extract -> Specify -> Export`
- verified each README contains served tracks, inputs, acceptance criteria, and source-ledger rules
- confirmed only the five issue #15 rispec folders are staged/committed

Closes #15
Refs miadisabelle/workspace-openclaw#80
