### PR TITLE
docs(rispecs): add Miadi Chronicle orchestration core

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Miadi-native Copilot orchestration assets for resumable STCKin and deep-search w
 ## Reusable RISE outputs
 
 - `rispecs/security-remediation-orchestration/` — reusable reverse-engineer, intent, specification, export, and provenance docs extracted from the issue-263 security-remediation evidence set.
+- `rispecs/miadi-chronicle-orchestration-core/` — bounded RISE core for Miadi Chronicle orientation, Tushell/Miadi continuity, Book One stewardship, chapter revision, and archive-first voice episode orchestration.
 
 ## Launch patterns
 

--- a/rispecs/miadi-chronicle-orchestration-core/01-reverse-engineer.md
+++ b/rispecs/miadi-chronicle-orchestration-core/01-reverse-engineer.md
@@ -1,0 +1,107 @@
+# Reverse-Engineer
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document reconstructs what the source evidence shows before defining future behavior. It uses the older Storyweaver rispec branch as contrast only.
+
+## Source surfaces inspected
+
+Current repo patterns:
+
+- `/workspace/worktrees/miadi-chronicle-orchestration-core/README.md`
+- `/workspace/worktrees/miadi-chronicle-orchestration-core/copilot/openclaw-model-routing-research-kit/README.md`
+- `/workspace/worktrees/miadi-chronicle-orchestration-core/copilot/stckin-orchestration-kit/README.md`
+
+Older Storyweaver branch contrast:
+
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/README.md`
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/04-agent-roster.md`
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/05-skill-surface.md`
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/06-state-and-handoff.md`
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/08-quality-gates-and-review.md`
+- `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/09-source-ledger.md`
+
+Storytelling framework sources:
+
+- `/src/storytelling/llms/docs/storytelling.md`
+- `/src/storytelling/llms/docs/narrative-craft.md`
+- `/src/storytelling/llms/docs/rise-framework.md`
+- `/src/storytelling/llms/docs/structural-tension.md`
+- `/src/storytelling/llms/docs/medicine-wheel-research.md`
+- `/src/storytelling/rispecs/ApplicationLogic.md`
+- `/src/storytelling/rispecs/Creative_Orientation_Operating_Guide.md`
+- `/src/storytelling/rispecs/Session_Management_Architecture.md`
+- `/src/storytelling/rispecs/Narrative_Intelligence_Integration_Specification.md`
+- `/src/storytelling/rispecs/Analytical_Feedback_Loop_Specification.md`
+
+Hermes chronicle and archive evidence:
+
+- `~/.hermes/voice-episodes/INDEX.md`
+- `~/.hermes/voice-episodes/miadi-chronicle/INDEX.md`
+- `~/.hermes/voice-episodes/miadi-chronicle/2026-05-04-episode-001-the-portal-and-the-tree/chapter-01-script.md`
+- `~/.hermes/voice-episodes/miadi-chronicle/2026-05-07-episode-006-continuity-note-and-book-one-outline/script.md`
+- `~/.hermes/voice-episodes/miadi-chronicle/2026-05-08-episode-007-book-one-point-of-view-shifts/script.md`
+- `~/.hermes/skills/creative/chronicle-chapter-revision/SKILL.md`
+- `~/.hermes/skills/media/voice-episode-archiving/SKILL.md`
+- `~/.hermes/skills/media/voice-episode-archiving/references/iris-kherix-interoperability.md`
+
+## What the older Storyweaver branch already contained
+
+| Observed pattern | Evidence surface | Status for this core |
+| --- | --- | --- |
+| A broad writing pipeline from brief intake through story bible, outline, chapter waves, review, and export. | Storyweaver `README.md`, `05-skill-surface.md`, `06-state-and-handoff.md` | Useful as contrast, too broad for this change. |
+| A future Copilot plugin target with many agents and skills. | Storyweaver `README.md`, `04-agent-roster.md`, `07-copilot-plugin-export.md` referenced by README | Deferred; this core is implementation-agnostic. |
+| Generic continuity ledgers, character arcs, timeline, review routes, and export packets. | Storyweaver `06-state-and-handoff.md`, `08-quality-gates-and-review.md` | Useful generic mechanics, but not sufficient for Miadi Chronicle continuity. |
+| A source ledger that cites `/src/storytelling`-style patterns and existing kit conventions. | Storyweaver `09-source-ledger.md` | Useful provenance style, but missing Hermes archive and Miadi/Tushell chronicle evidence. |
+
+## What was missing for the chronicle core
+
+The older branch did not treat these as first-class orchestration sources:
+
+- Hermes Agent as a direct consumer of the resulting kit, not only an external beneficiary.
+- `chronicle-chapter-revision` as an existing silent developmental review workflow for spoken chapters.
+- `voice-episode-archiving` as an archive-first workflow with stable episode folders, script, narration, audio, indexes, and optional metadata.
+- The Miadi Chronicle voice episode archive as durable design evidence.
+- Tushell as Portal of Knowing and Miadi as House of Orchestration as source reality for orientation and stewardship.
+- Continuity notes as branch/trunk return artifacts, not merely generic state notes.
+- Book One as a six-chapter orientation grammar, not an open-ended fiction outline.
+- Point-of-view shift as a stewardship transfer from Tushell-held entering toward Miadi-held carrying.
+- Recovery and split-audio archive behavior as evidence that audio episodes need durable, inspectable folders rather than only final prose.
+
+## Chronicle-specific evidence reconstructed
+
+| Reconstructed observation | Evidence surfaces |
+| --- | --- |
+| The Miadi Chronicle archive is organized as a voice episode series with a root index, series index, dated episode folders, scripts, narration files, audio files, and revision notes. | `~/.hermes/voice-episodes/INDEX.md`; `~/.hermes/voice-episodes/miadi-chronicle/INDEX.md`; `voice-episode-archiving/SKILL.md` |
+| Episode 001 names Tushell, Miadi, the Miadi Orchestration Kit, the PDE tree, and the chronicle as distinct but related houses/vessels. | Episode 001 `chapter-01-script.md` |
+| Tushell is positioned around entry and orientation, while Miadi is positioned around coordination, memory, handoffs, runtime truth, and accountable movement. | Episode 001 `chapter-01-script.md`; Episode 006 `script.md`; Episode 007 `script.md` |
+| Continuity notes preserve relation, summarize branch connection to prior work, carry the current question, and enable return to the trunk without rebuilding context. | Episode 006 `script.md` |
+| Branches are healthy when they make one child tension local and return with a clarified distinction, better question, reusable method, or new chronicle chapter. | Episode 006 `script.md` |
+| Book One currently has a six-chapter arc: threshold and bundle, parent question, houses of tension, orchestration grammar, branches/continuity/return, and transfer of stewardship. | Episode 006 `script.md`; Episode 007 `script.md` |
+| The Book One voice design favors a shift where Tushell holds the threshold and Miadi inherits the road. | Episode 007 `script.md` |
+| Chronicle chapter revision expects draft, silent developmental review, concise notes, targeted rewrite, and TTS-ready narration. | `chronicle-chapter-revision/SKILL.md` |
+| Durable voice episodes are promoted into `voice-episodes/` with stable folders, authored script, narration text, audio, indexes, and optional metadata/catalog fields. | `voice-episode-archiving/SKILL.md`; `iris-kherix-interoperability.md` |
+
+## Generic storytelling evidence worth retaining
+
+The `/src/storytelling` sources contribute reusable mechanics that should be adapted, not copied wholesale:
+
+- RISE phase discipline and specification-as-prose-code.
+- Structural tension blocks with desired outcome, current reality, and natural progression.
+- Persistent sessions and checkpoints at natural progression boundaries.
+- Narrative beats across technical, ceremonial, and story dimensions.
+- Narrative intelligence concepts: character state, theme, emotional target, beat metadata, and downstream analysis.
+- Analytical feedback loops that identify gaps, route targeted enrichment, validate results, and roll back harmful changes.
+
+For this core, these mechanics support chronicle continuity and review. They do not authorize a generic writing pipeline or runtime implementation.
+
+## Boundary of this stage
+
+Reverse-engineering stops at reconstruction:
+
+- what the older branch did and omitted,
+- what Hermes archive evidence proves directly,
+- what `/src/storytelling` contributes as reusable method,
+- what should stay provisional until future packaging work.
+
+Specification and export decisions belong in later RISE stages.

--- a/rispecs/miadi-chronicle-orchestration-core/02-intent.md
+++ b/rispecs/miadi-chronicle-orchestration-core/02-intent.md
@@ -1,0 +1,79 @@
+# Intent-Extract
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document extracts intent for a bounded Miadi Chronicle orchestration core. It does not define a plugin implementation.
+
+## Desired outcome
+
+Future agents can enter Miadi Chronicle work, read the right source surfaces, preserve Tushell/Miadi orientation, revise spoken chapters with the established Hermes workflow, maintain branch/trunk continuity, and archive audio episodes durably without recreating the orchestration model from scratch.
+
+Hermes Agent is an intended consumer of this core alongside Copilot, Codex, Claude, Gemini, Kherix, or later Miadi agents.
+
+## Current reality
+
+The older Storyweaver branch defines a large generic storytelling pipeline and future plugin target. It is useful, but it does not center the evidence that now matters most:
+
+- Hermes chronicle skills already exist.
+- The Miadi Chronicle archive already carries voice episode structure and continuity.
+- Book One already has a trunk arc and stewardship shift.
+- Tushell and Miadi already have distinct narrative responsibilities.
+- Audio output already depends on archive discipline, not just final text delivery.
+
+Without a smaller core, future agents may either merge the broad Storyweaver package too early or flatten the chronicle into generic fiction-writing guidance.
+
+## Structural tension
+
+| Current reality | Desired outcome | Natural progression |
+| --- | --- | --- |
+| Storyweaver is broad and plugin-forward. | Chronicle orchestration is small, grounded, and source-led. | Extract the chronicle core into RISE files before any plugin move. |
+| Hermes archive evidence is stronger than the old generic pipeline for this use case. | Hermes skills and episodes are treated as first-class sources. | Promote chapter revision and voice archive patterns into reusable knowledge. |
+| Book One exists as an emerging trunk with branch notes. | Agents preserve branch/trunk return and chapter arc continuity. | Require continuity notes and source-ledger entries before drafting or export. |
+| Tushell and Miadi can blur if treated as generic story elements. | The houses carry distinct orientation and stewardship responsibilities. | Make house responsibility part of review and POV expectations. |
+| Audio can be lost as cache or final-only media. | Audio episodes are durable, indexable, and resumable. | Require script, narration, audio, revision notes when useful, and index updates in future archive workflows. |
+
+## Natural progression
+
+This core advances through four moves:
+
+1. Reconstruct the evidence without importing the old Storyweaver plugin target.
+2. Name the chronicle-specific intent and boundaries.
+3. Specify the minimum reusable contract for continuity, review, archive, and export.
+4. Leave a later manifestation path for a Hermes skill, Copilot plugin, or archive schema only after use proves the boundary.
+
+## What good looks like
+
+Good chronicle orchestration produces:
+
+- a clear reading order,
+- a source ledger that separates direct evidence from inference,
+- a current chapter or episode contract,
+- continuity notes when branch work may return to a trunk,
+- review notes that are concise and separate from narration,
+- TTS-ready narration derived from revised script,
+- durable episode artifacts when audio is produced,
+- and a handoff that tells the next agent where the trunk, branch, and archive stand.
+
+## Non-goals
+
+This core does not:
+
+- merge the older Storyweaver branch,
+- create `copilot/miadi-storyweaver-orchestration-kit/`,
+- scaffold agents, skills, manifests, code, or archive generators,
+- define a full fiction-writing pipeline,
+- replace Hermes skills,
+- publish voice episodes,
+- migrate existing archive folders,
+- or claim that every future storytelling task must use the Miadi Chronicle form.
+
+## Pause conditions
+
+A future agent should pause or narrow scope when:
+
+- the governing trunk question is unclear,
+- a branch cannot state what it will return to the trunk,
+- Tushell/Miadi responsibility is blurred enough to change the chapter meaning,
+- sensitive cultural or personal material lacks authority or consent,
+- an audio artifact would be produced without a durable archive path,
+- or a claim cannot be placed in the source ledger as direct evidence, promoted pattern, or inference.

--- a/rispecs/miadi-chronicle-orchestration-core/03-specify.md
+++ b/rispecs/miadi-chronicle-orchestration-core/03-specify.md
@@ -1,0 +1,165 @@
+# Specify
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document defines the reusable orchestration contract for Miadi Chronicle work. It is implementation-agnostic and does not create a plugin.
+
+## Required reading order
+
+Before drafting, revising, or packaging chronicle work, read:
+
+1. the active user request or mission brief,
+2. this folder's `README.md`,
+3. `05-source-ledger.md`,
+4. the relevant Miadi Chronicle series index,
+5. the current episode or chapter scripts named by the task,
+6. the relevant Hermes skill guidance for chapter revision or voice episode archiving,
+7. `/src/storytelling` structural tension and session/feedback sources only as supporting method,
+8. the older Storyweaver branch only when the task asks for comparison or future plugin planning.
+
+## Workspace classes
+
+| Class | Role | Examples |
+| --- | --- | --- |
+| Kit repo | Reusable RISE knowledge and later package planning. | `rispecs/miadi-chronicle-orchestration-core/` |
+| Chronicle archive | Durable voice episode evidence and outputs. | `~/.hermes/voice-episodes/miadi-chronicle/` |
+| Hermes skill source | Existing operational workflows to promote as reusable knowledge. | `chronicle-chapter-revision`, `voice-episode-archiving` |
+| Storytelling framework source | Generic method references for RISE, session persistence, narrative intelligence, and feedback loops. | `/src/storytelling/...` |
+| Contrast branch | Older broad Storyweaver rispecs used for comparison, not merge authority. | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/...` |
+
+## Chronicle artifact contract
+
+Chronicle work should produce or update only the artifacts needed for the active stage.
+
+| Artifact | Required meaning |
+| --- | --- |
+| Chapter or episode script | Authored markdown with title, role, purpose, source context, and spoken structure. |
+| Revision notes | Concise developmental notes, separate from narration, naming strengths, risks, and targeted rewrite moves. |
+| Narration text | TTS-ready plain text derived from revised script, with markdown noise removed and spoken cadence considered. |
+| Audio file | Durable media artifact only when audio generation is in scope; predictable name such as `episode.ogg` or `chapter-XX.ogg`. |
+| Continuity note | Carryable orientation artifact for branch work, naming prior relation, current question, branch gain, trunk return, and next move. |
+| Source ledger | Claim-level provenance that separates direct evidence, promoted patterns, and inference. |
+| Handoff note | Short resume packet for the next agent: files read, files changed, current trunk, active branch, risks, and next authorized action. |
+
+## House responsibility contract
+
+Tushell and Miadi should be treated as governing orientations for chapter purpose and review.
+
+| House | Primary responsibility | Review question |
+| --- | --- | --- |
+| Tushell / Portal of Knowing | Entry, orientation, threshold, access, approach, first contact with complexity. | Does this help the listener enter without scattering or premature certainty? |
+| Miadi / House of Orchestration | Coordination, delegation, boundaries, runtime truth, handoffs, memory, lineage, accountable movement. | Does this help many actors, contexts, and responsibilities remain legible and trustworthy? |
+| Shared continuity zone | Branch/trunk relation, continuity notes, return gifts, Book One coherence. | Does this preserve relation between local inquiry and the governing trunk? |
+
+## Continuity contract
+
+When work happens on a branch, the future agent must record:
+
+- trunk question or Book One chapter arc it belongs to,
+- branch question being explored,
+- prior episode/chapter relation,
+- carryable gain produced by the branch,
+- whether the branch can return now or needs more exploration,
+- and what artifact should travel back to the trunk.
+
+A continuity note is required when:
+
+- the task resumes after interruption,
+- an episode changes the Book One arc,
+- a chapter shifts house responsibility or point of view,
+- a review branch produces a new framing,
+- or an archive split/recovery clip changes what counts as the canonical episode.
+
+## Book One contract
+
+Current Book One continuity should be treated as provisional but active trunk shape:
+
+| Chapter | Working title | Primary function | House orientation |
+| --- | --- | --- | --- |
+| 1 | The Threshold and the Bundle | Introduce the houses, bundle, PDE tree, and first law of situating before action. | Tushell |
+| 2 | The Parent Question | Compress the governing inquiry into one carryable sentence. | Tushell leaning toward Miadi |
+| 3 | Houses of Tension | Show decomposition without fragmentation: boundary, memory, runtime, lineage, delegation, human workflow. | Mixed |
+| 4 | The Orchestration Grammar | Teach handles such as boundary, handoff, memory, lineage, gate, scene, operator, and return. | Miadi |
+| 5 | Branches, Continuity, and Return | Explain healthy branching, continuity notes, and returning local gains to the trunk. | Miadi with Tushell memory |
+| 6 | The Transfer of Stewardship | Stage the shift from threshold voice to orchestration voice at the operator horizon. | Miadi |
+
+Future changes may revise this arc, but they must state whether they are direct evidence, promoted pattern, or inference in `05-source-ledger.md`.
+
+## Point-of-view and stewardship contract
+
+For Book One audio form, the current preferred design is:
+
+- Tushell holds the entering.
+- Miadi carries the road.
+- The hinge should be audible in topic and cadence.
+- The shift is a transfer of interpretive stewardship, not a stylistic trick.
+
+Any new chapter or revision should identify:
+
+- current narrator/custodian,
+- what truth that custodian can access,
+- what remains withheld or emerging,
+- where the next stewardship shift may happen,
+- and how the shift supports the listener's orientation.
+
+## Chapter revision contract
+
+When revising a chronicle chapter or interlude, use the reusable pattern from `chronicle-chapter-revision`:
+
+1. Draft the chapter with role, emotional purpose, concrete teaching purpose, and forward pull.
+2. Run a silent developmental review for orientation, teaching clarity, narrative motion, spoken-word quality, boundary discipline, and reusability.
+3. Save concise revision notes with strengths, risks, and 3 to 5 rewrite recommendations.
+4. Apply targeted rewrite only where needed.
+5. Derive TTS-ready narration from the revised script.
+
+The listener should receive the finished chapter, not the machinery of the review, unless transparency is requested.
+
+## Voice episode archive contract
+
+When audio archiving is in scope, future implementations should follow the archive-first pattern:
+
+- store durable episodes under `~/.hermes/voice-episodes/` or an explicitly supplied archive root,
+- keep one episode per stable folder,
+- save authored `script.md` or chapter-specific script files,
+- save `narration.txt` or chapter-specific narration files,
+- save predictable audio filenames,
+- save revision notes when the episode has editorial or continuity significance,
+- update root and series indexes,
+- treat `audio_cache/` as temporary provider/cache output,
+- and preserve private lineage fields only when appropriate for the target archive.
+
+This rispec records the contract; it does not generate audio or rewrite indexes.
+
+## Review gate
+
+Before a chronicle artifact is accepted, review for:
+
+- source-ledger grounding,
+- house responsibility clarity,
+- branch/trunk continuity,
+- Book One arc impact,
+- spoken cadence and TTS readiness,
+- archive durability when audio exists,
+- and separation between direct evidence, promoted pattern, and inference.
+
+Route decisions:
+
+| Route | Meaning |
+| --- | --- |
+| `accept` | The artifact can advance as-is. |
+| `revise` | Apply targeted changes and update revision notes. |
+| `continue-branch` | The branch has not produced a carryable return yet. |
+| `return-to-trunk` | The branch has a clear gain to integrate into the trunk. |
+| `pause` | Consent, source, archive, or continuity boundary blocks advancement. |
+
+## Export expectations
+
+Every export or handoff should name:
+
+- target consumer: Hermes Agent, Codex, Copilot, Claude, Gemini, Kherix, or human operator,
+- trunk and branch status,
+- accepted source claims,
+- provisional inferences,
+- changed artifacts,
+- archive actions taken or explicitly not taken,
+- and the next safe entry point.

--- a/rispecs/miadi-chronicle-orchestration-core/04-export.md
+++ b/rispecs/miadi-chronicle-orchestration-core/04-export.md
@@ -1,0 +1,93 @@
+# Export
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This document describes how the chronicle core can be exported into later work. It does not implement a plugin, skill, schema, archive generator, or migration.
+
+## Current export boundary
+
+The export for this change is the rispec package itself:
+
+```text
+rispecs/miadi-chronicle-orchestration-core/
+  README.md
+  01-reverse-engineer.md
+  02-intent.md
+  03-specify.md
+  04-export.md
+  05-source-ledger.md
+```
+
+The root `README.md` should list this as a reusable RISE output.
+
+## Future manifestation options
+
+Only after repeated use proves the boundary, a future wave could manifest this core as one or more of:
+
+| Future artifact | Possible role | Required source before implementation |
+| --- | --- | --- |
+| Hermes skill package | Let Hermes Agent invoke chronicle continuity, chapter revision, and voice archive review directly. | Current Hermes skill files plus this rispec. |
+| Copilot plugin folder | Provide agents/skills for chronicle orchestration across Codex/Copilot-style sessions. | Existing kit README patterns, source ledger, and a fresh implementation issue. |
+| Archive schema update | Normalize `episode.yaml`, catalog, and index generation around chronicle needs. | `voice-episode-archiving`, interoperability notes, and live archive examples. |
+| Review checklist | Lightweight reviewer for Book One continuity, house responsibility, and TTS readiness. | `03-specify.md` review gate and current chapter artifacts. |
+| Handoff template | Standard packet for branch/trunk return and future agent resume. | Episode 006 continuity-note evidence and this core's continuity contract. |
+
+## Future skill/package sketch
+
+A later package could expose a compact set of workflows:
+
+- `chronicle-session-orient`: read archive indexes, identify trunk/branch, name house responsibility, and prepare the next move.
+- `chronicle-continuity-note`: produce a branch/trunk return note with carryable gain and next entry point.
+- `chronicle-chapter-wave`: draft or revise one spoken chapter using silent developmental review and targeted rewrite.
+- `chronicle-voice-archive-review`: verify script, narration, audio, revision notes, metadata, and indexes.
+- `chronicle-source-ledger`: update direct evidence, promoted patterns, and inferences for chronicle work.
+
+These names are sketches, not implementation instructions.
+
+## Handoff shape
+
+Use this shape when handing the rispec to a future agent:
+
+```markdown
+## Rispec handoff: Miadi Chronicle Orchestration Core
+- RISE path: Reverse-engineer -> Intent-extract -> Specify -> Export
+- Target consumer:
+- Updated files:
+- Direct evidence used:
+- Promoted patterns:
+- Provisional inferences:
+- Active trunk:
+- Active branch:
+- Continuity note needed: yes/no
+- Archive action needed: yes/no
+- Next authorized action:
+```
+
+## Export rules
+
+- Export only claims supported in `05-source-ledger.md` or explicitly labelled as inference.
+- Do not treat the older Storyweaver branch as the canonical source for chronicle work.
+- Do not create a plugin from this package without a separate implementation issue or request.
+- Do not convert archive conventions into public publishing behavior unless the task explicitly authorizes publishing.
+- Do not expose private lineage fields from Hermes archives by default.
+- Preserve Hermes Agent as a consumer in package language; do not write only for external agents.
+
+## Resume instructions
+
+A later agent continuing this work should:
+
+1. read this file and `05-source-ledger.md`,
+2. inspect the active Miadi Chronicle index and latest relevant episode folder,
+3. identify whether the task is trunk work, branch work, archive review, chapter revision, or package manifestation,
+4. update only the smallest needed artifact set,
+5. leave a handoff with direct evidence, promoted patterns, inferences, and next entry point.
+
+## Stop conditions
+
+Stop before export if:
+
+- the target consumer is unclear,
+- the work would implement a plugin or skill without authorization,
+- the archive paths or episode identity are ambiguous,
+- the branch cannot state its trunk relation,
+- or a claim cannot be placed in the source ledger.

--- a/rispecs/miadi-chronicle-orchestration-core/05-source-ledger.md
+++ b/rispecs/miadi-chronicle-orchestration-core/05-source-ledger.md
@@ -1,0 +1,96 @@
+# Source Ledger
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+This ledger preserves provenance for the Miadi Chronicle orchestration core. It separates direct evidence, promoted patterns, and inference.
+
+## Source inventory
+
+| ID | Source | Type | Use |
+| --- | --- | --- | --- |
+| S1 | `/workspace/worktrees/miadi-chronicle-orchestration-core/README.md` | current repo | Root listing pattern for reusable kits and RISE outputs. |
+| S2 | `/workspace/worktrees/miadi-chronicle-orchestration-core/copilot/openclaw-model-routing-research-kit/README.md` | current repo | Example of focused kit README, launch boundary, and operating scope. |
+| S3 | `/workspace/worktrees/miadi-chronicle-orchestration-core/copilot/stckin-orchestration-kit/README.md` | current repo | Example of compact Miadi-native orchestration kit documentation. |
+| S4 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/README.md` | contrast branch | Broad Storyweaver mission, structural tension, plugin target, and read order. |
+| S5 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/04-agent-roster.md` | contrast branch | Generic writing-agent roster. |
+| S6 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/05-skill-surface.md` | contrast branch | Generic Storyweaver skill surface. |
+| S7 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/06-state-and-handoff.md` | contrast branch | Generic story workspace, continuity ledger, and resume semantics. |
+| S8 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/08-quality-gates-and-review.md` | contrast branch | Generic review gates and route format. |
+| S9 | `/workspace/repos/jgwill/miadi-orchestration-kit-storytelling-rispecs/rispecs/miadi-storyweaver-orchestration-kit/09-source-ledger.md` | contrast branch | Provenance style and promoted-claim structure. |
+| S10 | `/src/storytelling/llms/docs/storytelling.md` | framework docs | Story pipeline, checkpoints, RAG, IAIP, session persistence. |
+| S11 | `/src/storytelling/llms/docs/narrative-craft.md` | framework docs | Narrative beats across engineer, ceremony, and story dimensions. |
+| S12 | `/src/storytelling/llms/docs/rise-framework.md` | framework docs | RISE phase definitions and specification-as-prose-code framing. |
+| S13 | `/src/storytelling/llms/docs/structural-tension.md` | framework docs | Desired outcome/current reality/action structure and tension language. |
+| S14 | `/src/storytelling/llms/docs/medicine-wheel-research.md` | framework docs | Four Directions, Two-Eyed AI, relational/ceremonial framing. |
+| S15 | `/src/storytelling/rispecs/ApplicationLogic.md` | framework rispec | Story foundation, chapter layering, critique/revision, polish/export flow. |
+| S16 | `/src/storytelling/rispecs/Creative_Orientation_Operating_Guide.md` | framework rispec | Structural tension block and advancing-language rules. |
+| S17 | `/src/storytelling/rispecs/Session_Management_Architecture.md` | framework rispec | Persistent creative sessions, checkpoints, resume, branching opportunities. |
+| S18 | `/src/storytelling/rispecs/Narrative_Intelligence_Integration_Specification.md` | framework rispec | StoryBeat, character state, theme, emotion, analysis readiness. |
+| S19 | `/src/storytelling/rispecs/Analytical_Feedback_Loop_Specification.md` | framework rispec | Analysis, gap routing, enrichment, validation, rollback. |
+| S20 | `~/.hermes/voice-episodes/INDEX.md` | Hermes archive | Root voice episode index and Miadi Chronicle series entry. |
+| S21 | `~/.hermes/voice-episodes/miadi-chronicle/INDEX.md` | Hermes archive | Miadi Chronicle episode list, focus notes, and artifact listings. |
+| S22 | `~/.hermes/voice-episodes/miadi-chronicle/2026-05-04-episode-001-the-portal-and-the-tree/chapter-01-script.md` | Hermes archive | Tushell/Miadi source reality, orchestration kit bundle, PDE tree, chronicle vessel. |
+| S23 | `~/.hermes/voice-episodes/miadi-chronicle/2026-05-07-episode-006-continuity-note-and-book-one-outline/script.md` | Hermes archive | Continuity note, branch/trunk return, Book One six-chapter outline. |
+| S24 | `~/.hermes/voice-episodes/miadi-chronicle/2026-05-08-episode-007-book-one-point-of-view-shifts/script.md` | Hermes archive | POV options, Tushell/Miadi complementarity, Book One audio outline, stewardship shift. |
+| S25 | `~/.hermes/skills/creative/chronicle-chapter-revision/SKILL.md` | Hermes skill | Silent developmental review, concise notes, targeted rewrite, TTS-ready narration, chapter artifact shape. |
+| S26 | `~/.hermes/skills/media/voice-episode-archiving/SKILL.md` | Hermes skill | Durable voice episode folders, script/narration/audio/indexes, archive-first behavior. |
+| S27 | `~/.hermes/skills/media/voice-episode-archiving/references/iris-kherix-interoperability.md` | Hermes skill reference | `voice-episode/v1` metadata direction, cache vs archive distinction, cross-agent levels. |
+
+## Direct evidence claims
+
+| Claim ID | Claim | Sources | Status |
+| --- | --- | --- | --- |
+| D1 | The older Storyweaver branch is broad, writing-pipeline-oriented, and points toward a future Copilot plugin implementation. | S4, S5, S6, S7, S8 | Direct evidence |
+| D2 | The current repo already lists reusable RISE outputs separately from Copilot kits. | S1 | Direct evidence |
+| D3 | `/src/storytelling` supports RISE, structural tension, session persistence, narrative beats, narrative intelligence, and analytical feedback loops. | S10-S19 | Direct evidence |
+| D4 | The Hermes voice archive has a `miadi-chronicle` series with indexed episodes and artifact lists. | S20, S21 | Direct evidence |
+| D5 | Episode 001 identifies Tushell as Portal of Knowing and Miadi as House of Orchestration, with the chronicle as a spoken vessel for making the work intelligible. | S22 | Direct evidence |
+| D6 | Episode 006 defines continuity notes as carryable orientation artifacts for branch work returning to a trunk. | S23 | Direct evidence |
+| D7 | Episode 006 and Episode 007 both present a six-chapter Book One arc. | S23, S24 | Direct evidence |
+| D8 | Episode 007 describes a point-of-view/stewardship shift where Tushell holds entering/orientation and Miadi carries coordination/accountability. | S24 | Direct evidence |
+| D9 | `chronicle-chapter-revision` prescribes draft, silent developmental review, concise revision notes, targeted rewrite, and TTS preparation. | S25 | Direct evidence |
+| D10 | `voice-episode-archiving` prescribes stable voice episode folders, `script.md`, `narration.txt`, `episode.ogg`, indexes, and archive-first promotion. | S26 | Direct evidence |
+| D11 | `voice-episode/v1` interoperability separates temporary `audio_cache/` from durable `voice-episodes/` archives and suggests metadata/catalog fields. | S27 | Direct evidence |
+
+## Promoted patterns
+
+| Pattern ID | Promoted orchestration rule | Source support | Scope |
+| --- | --- | --- | --- |
+| P1 | Chronicle work must begin by situating house, trunk, branch, and archive context before drafting or revising. | D5, D6, D8 | Durable chronicle core |
+| P2 | Tushell/Miadi distinctions are review criteria for chapter purpose, not only worldbuilding flavor. | D5, D8 | Durable chronicle core |
+| P3 | Continuity notes are required when branch work needs to return a carryable gain to the trunk. | D6, D7 | Durable chronicle core |
+| P4 | Book One's six-chapter outline is the active trunk shape until a later source-ledger entry revises it. | D7, D8 | Active trunk pattern |
+| P5 | Chapter revision should use silent developmental review, concise notes, targeted rewrite, and TTS-ready narration. | D9 | Reusable workflow |
+| P6 | Voice episodes should be archive-first artifacts, not cache-only audio outputs. | D10, D11 | Reusable workflow |
+| P7 | Hermes Agent should be treated as a consumer of the resulting orchestration knowledge. | S25, S26 | Reusable package boundary |
+| P8 | Generic Storyweaver agents/skills may inform future packaging, but they should not override Hermes archive evidence. | D1, D4-D11 | Promotion boundary |
+
+## Inferences
+
+| Inference ID | Inference | Basis | Required caution |
+| --- | --- | --- | --- |
+| I1 | A smaller RISE core is safer than merging the older Storyweaver branch as-is. | D1 compared with D4-D11 | This is a design inference for this change, not a permanent rejection of Storyweaver. |
+| I2 | A future plugin or skill package may expose workflows such as orient, continuity note, chapter wave, archive review, and source ledger. | P1-P6 plus repo kit patterns S1-S3 | Do not implement without a later request or issue. |
+| I3 | Archive schema work may eventually benefit from `episode.yaml` and `catalog.jsonl`. | D11 | Current Miadi Chronicle examples do not all prove that schema is already present. |
+| I4 | Book One's POV shift should be tested in cadence as well as topic. | D8 plus `chronicle-chapter-revision` spoken-quality lens D9 | Treat as creative guidance, not a rigid style rule. |
+
+## Contradictions and boundaries
+
+| Boundary | Handling |
+| --- | --- |
+| Older Storyweaver branch expects a future plugin; current task forbids creating one. | Keep export guidance future-facing and implementation-agnostic. |
+| `/src/storytelling` is a generic generation package, while the target is chronicle orchestration. | Promote only method-level patterns; do not import runtime assumptions. |
+| `voice-episode/v1` metadata is suggested by interoperability notes, while current archive examples are mostly markdown/index/audio artifacts. | Mark schema/catalog claims as future-compatible inference unless direct files exist in the target episode. |
+| Book One outline is active but still evolving. | Treat as current trunk pattern, not immutable canon. |
+| Hermes archive paths may contain private local lineage. | Cite paths for provenance; do not publish private fields by default. |
+
+## Cleared for use in this package
+
+The following claims are cleared for current synthesis:
+
+- The core must be chronicle/orientation/continuity/audio-archive specific.
+- Tushell and Miadi should be encoded as source reality and review responsibilities.
+- Continuity note, branch/trunk return, Book One arc, and POV/stewardship shift belong in the spec.
+- Chronicle chapter revision and voice episode archiving are reusable orchestration knowledge.
+- The older Storyweaver branch is contrast/reference, not merge authority.
+- Future packaging can be described but not implemented in this change.

--- a/rispecs/miadi-chronicle-orchestration-core/README.md
+++ b/rispecs/miadi-chronicle-orchestration-core/README.md
@@ -1,0 +1,55 @@
+# Miadi Chronicle Orchestration Core
+
+RISE path: `Reverse-engineer -> Intent-extract -> Specify -> Export`
+
+Focused orchestration rispecs for chronicle, orientation, continuity, and audio-archive work around the Miadi Chronicle. This package is a revision-before-merge core extracted into current main. It is not a merge of the older broad Storyweaver rispec branch and it does not create a Copilot plugin.
+
+## Structural tension
+
+- **Desired outcome**: Future agents, including Hermes Agent itself, can consume a small Miadi-native chronicle core that preserves Tushell/Miadi orientation, branch continuity, Book One shape, chapter revision, and archive-first voice episode discipline.
+- **Current reality**: The older Storyweaver rispec branch describes a generic writing pipeline and plugin target, while the strongest current evidence lives in Hermes skills, Miadi Chronicle voice episodes, Book One continuity notes, and archive folders.
+- **Natural progression**: Reverse-engineer the source reality, extract the chronicle-specific intent, specify implementation-agnostic orchestration expectations, and leave export guidance for a later skill or plugin package only when repeated use proves the boundary.
+
+## Source reality
+
+This core treats the following as first-class source reality, not decorative story language:
+
+- Tushell is the Portal of Knowing: orientation, entry, threshold, access, and how a traveler meets complexity without scattering.
+- Miadi is the House of Orchestration: coordination, delegation, memory, lineage, runtime boundaries, handoffs, and accountable movement.
+- The Miadi Chronicle is a spoken vessel for making orchestration work humanly intelligible.
+- Continuity notes preserve relation between branch work and trunk inquiry.
+- Book One currently carries a six-chapter orientation arc with a point-of-view and stewardship shift from Tushell toward Miadi.
+- Voice episodes are durable archive artifacts with scripts, narration text, audio, revision notes when useful, and indexes.
+
+## Read order
+
+| File | Purpose |
+| --- | --- |
+| `01-reverse-engineer.md` | Compares older Storyweaver assumptions with Hermes chronicle/archive evidence and names what was missing. |
+| `02-intent.md` | Defines desired outcome, current reality, structural tension, non-goals, and natural progression for this smaller core. |
+| `03-specify.md` | Defines the reusable contract for chronicle work: workspace classes, artifacts, review, continuity, archive, and export expectations. |
+| `04-export.md` | Describes how future agents could manifest a skill or plugin package later without implementing it in this change. |
+| `05-source-ledger.md` | Preserves direct evidence, promoted patterns, inferences, and source boundaries. |
+
+## Scope
+
+This package is about chronicle/orientation/continuity/audio-archive orchestration. It is not a generic fiction-writing kit, a manuscript generator, a publishing platform, or a Copilot plugin implementation.
+
+Use it when work involves:
+
+- Miadi Chronicle chapters, interludes, continuity notes, or Book One planning,
+- Tushell/Miadi orientation and stewardship distinctions,
+- branch/trunk return logic in a knowledge tree,
+- Hermes voice episode archive conventions,
+- chapter revision for spoken output,
+- or future agent-facing packaging of these patterns.
+
+## Acceptance criteria
+
+- The package stays in the standard five-file RISE shape plus README.
+- Claims about source reality are ledger-backed or explicitly marked as inference.
+- Hermes skills and voice episodes are treated as orchestration sources, not only private outputs.
+- The older Storyweaver branch is used only as contrast/reference.
+- Tushell, Miadi, continuity notes, branch/trunk return, Book One chapter arc, and POV/stewardship shift are explicit.
+- Chapter revision and voice episode archiving are reusable knowledge.
+- No plugin, runtime code, schema generator, or archive migration is implemented here.


### PR DESCRIPTION
## Summary
- add `rispecs/miadi-chronicle-orchestration-core/` as a bounded RISE package for chronicle/orientation/continuity/audio-archive orchestration
- ground the spec in Hermes skill workflows, Miadi Chronicle voice archives, and Tushell/Miadi Book One continuity instead of generic fiction-pipeline assumptions
- update the root README to list the new reusable RISE output

## Why
The existing storytelling branch / PR #10 is useful but too broad to merge as-is for this need. This PR extracts a smaller chronicle core first, so future Storyweaver or plugin work can build on source-ledgered Miadi/Tushell continuity and Hermes voice-archive practice.

## Source grounding
- `chronicle-chapter-revision`
- `voice-episode-archiving`
- `~/.hermes/voice-episodes/miadi-chronicle/*`
- `/src/storytelling/*`
- existing `codex/storytelling-orchestration-rispecs` branch as contrast/reference only

## Validation
- `git diff --check`
- readback of new RISE files and root README